### PR TITLE
Genome browser - channel creation and multiple track support.

### DIFF
--- a/webapp/src/js/components/containers/DataItem.js
+++ b/webapp/src/js/components/containers/DataItem.js
@@ -36,7 +36,7 @@ let DataItem = React.createClass({
 
   getDefaultProps: function() {
     return {
-      activeTab: 'view_2'
+      activeTab: 'view_0'
     };
   },
 

--- a/webapp/src/js/components/containers/GenomeBrowserWithActions.js
+++ b/webapp/src/js/components/containers/GenomeBrowserWithActions.js
@@ -2,7 +2,6 @@ import React from 'react';
 import Immutable from 'immutable';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import PureRenderMixin from 'mixins/PureRenderMixin';
-import uid from 'uid';
 
 import FluxMixin from 'mixins/FluxMixin';
 import ConfigMixin from 'mixins/ConfigMixin';
@@ -48,11 +47,11 @@ let GenomeBrowserWithActions = React.createClass({
     return this.props.title || 'Genome Browser';
   },
 
-  handleChannelAdd(component) {
+  handleChannelAdd(newChannels) {
     this.getFlux().actions.session.modalClose();
     this.props.componentUpdate(
-      (props) => props.update('components',
-        (components) => components.set(uid(10), component)));
+      (props) => props.update('channels',
+        (components) => components.merge(newChannels)));
   },
 
   render() {
@@ -80,7 +79,7 @@ let GenomeBrowserWithActions = React.createClass({
                   onClick={() => componentUpdate({sidebar: !sidebar})}/>
             <span className="text">WTF</span>
           </div>
-          <GenomeBrowser componentUpdate={componentUpdate} sideWidth={100} {...subProps} />
+          <GenomeBrowser componentUpdate={componentUpdate} sideWidth={200} {...subProps} />
         </div>
       </Sidebar>
     );

--- a/webapp/src/js/components/containers/GenomeBrowserWithActions.js
+++ b/webapp/src/js/components/containers/GenomeBrowserWithActions.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Immutable from 'immutable';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import PureRenderMixin from 'mixins/PureRenderMixin';
+import uid from 'uid';
 
 import FluxMixin from 'mixins/FluxMixin';
 import ConfigMixin from 'mixins/ConfigMixin';
@@ -38,8 +39,6 @@ let GenomeBrowserWithActions = React.createClass({
     };
   },
 
-  componentWillMount() {
-  },
 
   icon() {
     return 'bitmap:genomebrowser.png';
@@ -49,14 +48,25 @@ let GenomeBrowserWithActions = React.createClass({
     return this.props.title || 'Genome Browser';
   },
 
+  handleChannelAdd(component) {
+    this.getFlux().actions.session.modalClose();
+    this.props.componentUpdate(
+      (props) => props.update('components',
+        (components) => components.set(uid(10), component)));
+  },
+
   render() {
+    let actions = this.getFlux().actions;
     let {sidebar, componentUpdate, ...subProps} = this.props;
     let sidebarContent = (
       <div className="sidebar">
         <SidebarHeader icon={this.icon()} description="A browser for exploring the reference genome and per-sample data including coverage and mapping qualities."/>
-        <FlatButton label="Add Channel"
+        <FlatButton label="Add Channels"
                     primary={true}
-                    onClick={null}/>
+                    onClick={() => actions.session.modalOpen('panoptes/genome/AddChannel.js',
+                      {
+                        onPick: this.handleChannelAdd
+                      })}/>
       </div>
     );
     return (

--- a/webapp/src/js/components/containers/ItemPicker.js
+++ b/webapp/src/js/components/containers/ItemPicker.js
@@ -107,12 +107,12 @@ let ItemPicker = React.createClass({
                   let {id, name, properties} = group;
                   let subItems = properties.map((prop) => {
                     let {name, description, propid} = prop;
-                    return (name + '#' + description).toLowerCase().indexOf(search.toLowerCase()) > -1 ? (
+                    return (`${name}#${(description || '')}`).toLowerCase().indexOf(search.toLowerCase()) > -1 ? (
                           <ListItem className={classNames({picked: picked.includes(propid)})}
                                     key={propid}
                                     primaryText={<div><Highlight search={search}>{name}</Highlight></div>}
                                     secondaryText={<div><Highlight search={search}>{description}</Highlight></div>}
-                                    leftIcon={<div><Icon fixedWidth={true} name={picked.includes(propid) ? 'minus' : 'plus'} /></div>}
+                                    //leftIcon={<div><Icon fixedWidth={true} name={picked.includes(propid) ? 'minus' : 'plus'} /></div>}
                                     onClick={() => this.handleAdd(propid)}
                             />) : null;
                   }
@@ -121,7 +121,7 @@ let ItemPicker = React.createClass({
                     <ListItem primaryText={name}
                               key={id}
                               initiallyOpen={true}
-                              leftIcon={<div><Icon fixedWidth={true} name="plus"/></div>}
+                              //leftIcon={<div><Icon fixedWidth={true} name="plus"/></div>}
                               onClick={() => this.handleAddAll(id)}
                               nestedItems={subItems}
                       />
@@ -142,7 +142,7 @@ let ItemPicker = React.createClass({
                           <ListItem primaryText={name}
                                     key={id}
                                     initiallyOpen={true}
-                                    leftIcon={<div><Icon fixedWidth={true} name="minus"/></div>}
+                                    //leftIcon={<div><Icon fixedWidth={true} name="minus"/></div>}
                                     onClick={() => this.handleRemoveAll(id)}
                                     nestedItems={
                         properties.map((prop) => {
@@ -151,7 +151,7 @@ let ItemPicker = React.createClass({
                               <ListItem key={propid}
                                         secondaryText={description}
                                         primaryText={name}
-                                        leftIcon={<div><Icon fixedWidth={true} name="minus"/></div>}
+                                        //leftIcon={<div><Icon fixedWidth={true} name="minus"/></div>}
                                         onClick={() => this.handleRemove(propid)}/>
                             ) : null;
                         }

--- a/webapp/src/js/components/containers/ItemPicker.js
+++ b/webapp/src/js/components/containers/ItemPicker.js
@@ -106,13 +106,13 @@ let ItemPicker = React.createClass({
                 _map(groups.toJS(), (group) => {
                   let {id, name, properties} = group;
                   let subItems = properties.map((prop) => {
-                    let {name, description, propid} = prop;
+                    let {name, description, propid,  icon} = prop;
                     return (`${name}#${(description || '')}`).toLowerCase().indexOf(search.toLowerCase()) > -1 ? (
-                          <ListItem className={classNames({picked: picked.includes(propid)})}
+                          <ListItem className={classNames({picked: !picked.includes(propid)})}
                                     key={propid}
                                     primaryText={<div><Highlight search={search}>{name}</Highlight></div>}
                                     secondaryText={<div><Highlight search={search}>{description}</Highlight></div>}
-                                    //leftIcon={<div><Icon fixedWidth={true} name={picked.includes(propid) ? 'minus' : 'plus'} /></div>}
+                                    leftIcon={<div><Icon fixedWidth={true} name={icon} /></div>}
                                     onClick={() => this.handleAdd(propid)}
                             />) : null;
                   }
@@ -142,16 +142,16 @@ let ItemPicker = React.createClass({
                           <ListItem primaryText={name}
                                     key={id}
                                     initiallyOpen={true}
-                                    //leftIcon={<div><Icon fixedWidth={true} name="minus"/></div>}
                                     onClick={() => this.handleRemoveAll(id)}
                                     nestedItems={
                         properties.map((prop) => {
-                          let {name, description, propid} = prop;
+                          console.log(prop);
+                          let {name, description, propid, icon} = prop;
                           return picked.includes(propid) ? (
                               <ListItem key={propid}
                                         secondaryText={description}
                                         primaryText={name}
-                                        //leftIcon={<div><Icon fixedWidth={true} name="minus"/></div>}
+                                        leftIcon={<div><Icon fixedWidth={true} name={icon}/></div>}
                                         onClick={() => this.handleRemove(propid)}/>
                             ) : null;
                         }

--- a/webapp/src/js/components/panoptes/genome/AddChannel.js
+++ b/webapp/src/js/components/panoptes/genome/AddChannel.js
@@ -1,0 +1,174 @@
+import React from 'react';
+import PureRenderMixin from 'mixins/PureRenderMixin';
+import _forEach from 'lodash/forEach';
+import _map from 'lodash/map';
+import _filter from 'lodash/forEach';
+import LinkedStateMixin from 'react-addons-linked-state-mixin';
+import Immutable from 'immutable';
+import classNames from 'classnames';
+import Highlight from 'react-highlighter';
+import ConfigMixin from 'mixins/ConfigMixin';
+import Pluralise from 'ui/Pluralise';
+
+
+import TextField from 'material-ui/lib/text-field';
+import RaisedButton from 'material-ui/lib/raised-button';
+import List from 'material-ui/lib/lists/list';
+import ListItem from 'material-ui/lib/lists/list-item';
+
+import Icon from 'ui/Icon';
+
+
+let ItemPicker = React.createClass({
+  mixins: [
+    PureRenderMixin,
+    LinkedStateMixin,
+    ConfigMixin
+  ],
+
+  propTypes: {
+    onPick: React.PropTypes.func.isRequired
+  },
+
+  getDefaultProps() {
+    return {};
+  },
+
+  getInitialState() {
+    return {
+      picked: Immutable.OrderedSet(),
+      search: ''
+    };
+  },
+
+  componentWillMount() {
+    this.propertyGroups = Immutable.Map();
+    _forEach(this.config.summaryValues, (val, key) => {
+      this.propertyGroups = this.propertyGroups.set(key, {
+        properties: val,
+        id: key,
+        name: key === '__reference__' ? 'Reference' : this.config.tables[key].tableCapNamePlural,
+        icon: key === '__reference__' ? 'bitmap:genomebrowser.png' : this.config.tables[key].icon
+      });
+    });
+
+  },
+
+  icon() {
+    return 'check-square-o';
+  },
+  title() {
+    return 'Add genome track';
+  },
+
+  handleEnter() {
+    this.handlePick();
+  },
+
+  handleAdd(groupId, propId) {
+    if (this.state.picked.has(`${groupId}\t${propId}`))
+      this.setState({picked: this.state.picked.delete(`${groupId}\t${propId}`)});
+    else
+      this.setState({picked: this.state.picked.add(`${groupId}\t${propId}`)});
+  },
+  handleAddAll(groupId) {
+    let toAdd = _map(this.propertyGroups.get(groupId).properties, (prop) => `${groupId}\t${prop.propid}`);
+    this.setState({picked: this.state.picked.union(toAdd)});
+  },
+  handleRemove(groupId, propId) {
+    this.setState({picked: this.state.picked.delete(`${groupId}\t${propId}`)});
+  },
+  handleRemoveAll(groupId) {
+    let toRemove = _map(this.propertyGroups.get(groupId).properties, (prop) => `${groupId}\t${prop.propid}`);
+    this.setState({picked: this.state.picked.subtract(toRemove)});
+  },
+
+  handlePick() {
+    this.props.onPick(Immutable.fromJS({
+      component: 'NumericalChannel',
+      props: {
+        tracks: this.state.picked
+      }
+    }));
+  },
+
+  render() {
+    let {picked, search} = this.state;
+    let groups = this.propertyGroups;
+    let count = groups.map((group) => Object.keys(group.properties).length).reduce((sum, v) => sum + v, 0);
+    return (
+      <div className='large-modal item-picker'>
+        <div className="horizontal stack">
+          <div className="grow scroll-within">
+            <div className="header">{count} <Pluralise text="Track" ord={count}/> Available</div>
+            <div className="search">
+              <TextField floatingLabelText="Search" valueLink={this.linkState('search')}/>
+            </div>
+            <List>
+              {
+                groups.map((group) => {
+                  let {id, name, icon, properties} = group;
+                  let subItems = _map(properties, (prop) => {
+                      let {name, description, propid} = prop;
+                      return (name + "#" + (description || '')).toLowerCase().indexOf(search.toLowerCase()) > -1 ? (
+                        <ListItem className={classNames({picked: picked.includes(`${id}\t${propid}`)})}
+                                  key={propid}
+                                  primaryText={<div><Highlight search={search}>{name}</Highlight></div>}
+                                  secondaryText={<div><Highlight search={search}>{description}</Highlight></div>}
+                          //leftIcon={<div><Icon fixedWidth={true} name={picked.includes(`${id}\t${propid}`) ? "minus" : "plus"} /></div>}
+                                  onClick={() => this.handleAdd(id, propid)}
+                        />) : null;
+                    }
+                  );
+                  let numberSubItems = subItems.filter((i) => i).length;
+                  return numberSubItems > 0 ? (
+                    <ListItem
+                      primaryText={<div> {name} ({numberSubItems} <Pluralise text="Track" ord={numberSubItems}/>)</div>}
+                      key={id}
+                      initiallyOpen={true}
+                      leftIcon={<Icon fixedWidth={true} name={icon}/>}//<div><Icon fixedWidth={true} name="plus"/></div>}
+                      onClick={() => this.handleAddAll(id)}
+                      nestedItems={subItems}
+                    />
+
+                  ) : null;
+                }).toArray()
+              }
+            </List>
+          </div>
+          <div className="grow stack vertical">
+            <div className="grow scroll-within">
+              <div className="header">{picked.size ? picked.size : 'No'} <Pluralise text="Track" ord={picked.size}/> to
+                Add
+              </div>
+              <List>
+                {
+                  picked.map((trackId) => {
+                    let [id, propid] = trackId.split('\t');
+                    let {icon} = groups.get(id);
+                    let groupName = groups.get(id).name;
+                    let {description, name} = groups.get(id).properties[propid];
+                    return <ListItem key={trackId}
+                                     secondaryText={description}
+                                     primaryText={`${groupName} - ${name}`}
+                                     leftIcon={<div><Icon fixedWidth={true} name={icon}/></div>}
+                                     onClick={() => this.handleRemove(id, propid)}/>;
+
+                  }).toArray()
+                }
+
+              </List>
+            </div>
+            <div className='centering-container'>
+              <RaisedButton label="Use" primary={true} onClick={this.handlePick}/>
+
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+});
+
+module.exports = ItemPicker;

--- a/webapp/src/js/components/panoptes/genome/GenomeBrowser.js
+++ b/webapp/src/js/components/panoptes/genome/GenomeBrowser.js
@@ -202,7 +202,7 @@ let GenomeBrowser = React.createClass({
 
   render() {
     let {settings} = this.config;
-    let {start, end, sideWidth, chromosome, components} = this.props;
+    let {start, end, sideWidth, chromosome, channels} = this.props;
     let {loading} = this.state;
     if (!_has(this.config.chromosomes, chromosome))
       console.log('Unrecognised chromosome in genome browser', chromosome);
@@ -230,7 +230,7 @@ let GenomeBrowser = React.createClass({
             onDoubleTap={this.handleDoubleTap}
             onPan={this.handlePan}
             vertical={true}
-            onPinch={(e) => console.log('2', e)}
+            onPinch={(e) => console.log('Pinch not implemented', e)}
             onWheel={this.handleMouseWheel}
           >
             <div className="main-area">
@@ -266,18 +266,18 @@ let GenomeBrowser = React.createClass({
                           null }
                       </div>
                       <div className="scrolling grow scroll-within">
-                        {components.map((componentSpec, componentId) => {
-                          let {component, props} = componentSpec.toJS();
-                          return React.createElement(dynamicRequire(component),
+                        {channels.map((channel, channelId) => {
+                          let props = channel.get('props');
+                          return React.createElement(dynamicRequire(channel.get('channel')),
                               Object.assign({
-                                key: componentId,
+                                key: channelId,
                                 componentUpdate: (updater) => this.componentUpdate((props) => {
                                   if (_isFunction(updater))
-                                    return props.updateIn(['components', componentId, 'props'], updater);
+                                    return props.updateIn(['channels', channelId, 'props'], updater);
                                   else
-                                    return props.mergeIn(['components', componentId, 'props'], updater);
+                                    return props.mergeIn(['channels', channelId, 'props'], updater);
                                 })
-                              }, props, trackProps));
+                              }, props.toObject(), trackProps));
                         }
                         ).toList()
                         }

--- a/webapp/src/js/components/panoptes/genome/GenomeBrowser.js
+++ b/webapp/src/js/components/panoptes/genome/GenomeBrowser.js
@@ -255,7 +255,7 @@ let GenomeBrowser = React.createClass({
                   };
                   return (
                     <div className="tracks vertical stack">
-                      <Background start={start} end={end} width={width} height={height - CONTROLS_HEIGHT}
+                      <Background start={start} end={end} width={width} height={Math.max(0,height - CONTROLS_HEIGHT)}
                                   sideWidth={sideWidth}/>
 
                       <div className="fixed">

--- a/webapp/src/js/components/panoptes/genome/tracks/NumericalChannel.js
+++ b/webapp/src/js/components/panoptes/genome/tracks/NumericalChannel.js
@@ -97,6 +97,13 @@ let NumericalChannel = React.createClass({
       }
     }
 
+    //If we go to a region with no data then don't move the y axis
+    if (!_isFinite(yMin) && this.lastYMin)
+      yMin = this.lastYMin;
+    if (!_isFinite(yMax) && this.lastYMax)
+      yMax = this.lastYMax;
+    [this.lastYMin, this.lastYMax] = [yMin, yMax];
+
     if (width === 0)
       return null;
 

--- a/webapp/src/js/components/panoptes/genome/tracks/NumericalChannel.js
+++ b/webapp/src/js/components/panoptes/genome/tracks/NumericalChannel.js
@@ -76,7 +76,7 @@ let NumericalChannel = React.createClass({
 
   render() {
     let height = HEIGHT;
-    let config = this.config.summaryValues.__reference__.uniqueness;
+    let config = this.config.summaryValues.__reference__.Uniqueness;
     let props = Object.assign({
       yMin: config.minval,
       yMax: config.maxval

--- a/webapp/src/js/components/panoptes/genome/tracks/NumericalChannel.js
+++ b/webapp/src/js/components/panoptes/genome/tracks/NumericalChannel.js
@@ -1,15 +1,14 @@
 import React from 'react';
-
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import d3 from 'd3';
 import _isFinite from 'lodash/isFinite';
+import _map from 'lodash/map';
 
 
 import ConfigMixin from 'mixins/ConfigMixin';
-import FluxMixin from 'mixins/FluxMixin';
 import PureRenderWithComponentUpdateException from 'mixins/PureRenderWithComponentUpdateException';
 
 import ChannelWithConfigDrawer from 'panoptes/genome/tracks/ChannelWithConfigDrawer';
-import NumericalTrack from 'panoptes/genome/tracks/NumericalTrack';
 import YScale from 'panoptes/genome/tracks/YScale';
 
 
@@ -20,6 +19,10 @@ import Slider from 'material-ui/lib/slider';
 import {Motion, spring} from 'react-motion';
 
 import findBlocks from 'panoptes/genome/FindBlocks';
+
+let dynreq = require.context('.', true);
+const dynamicRequire = (path) => dynreq('./' + path);
+
 
 const HEIGHT = 100;
 const INTERPOLATIONS = [
@@ -37,8 +40,7 @@ const INTERPOLATION_HAS_TENSION = {
 let NumericalChannel = React.createClass({
   mixins: [
     PureRenderWithComponentUpdateException(),
-    ConfigMixin,
-    FluxMixin
+    ConfigMixin
   ],
 
   propTypes: {
@@ -52,13 +54,16 @@ let NumericalChannel = React.createClass({
     autoYScale: React.PropTypes.bool,
     tension: React.PropTypes.number,
     yMin: React.PropTypes.number,
-    yMax: React.PropTypes.number
+    yMax: React.PropTypes.number,
+    tracks: ImmutablePropTypes.listOf(
+      ImmutablePropTypes.contains({
+        track: React.PropTypes.string.isRequired,
+        props: ImmutablePropTypes.map
+      }))
   },
 
   getInitialState() {
     return {
-      dataYMin: null,
-      dataYMax: null
     };
   },
 
@@ -70,22 +75,26 @@ let NumericalChannel = React.createClass({
     };
   },
 
-  handleYLimitChange({dataYMin, dataYMax}) {
-    this.setState({dataYMin, dataYMax});
+  handleYLimitChange({index, dataYMin, dataYMax}) {
+    this.setState({[index]: {dataYMin, dataYMax}});
   },
 
   render() {
     let height = HEIGHT;
-    let config = this.config.summaryValues.__reference__.Uniqueness;
-    let props = Object.assign({
-      yMin: config.minval,
-      yMax: config.maxval
-    }, this.props);
-    let {start, end, width, sideWidth, yMin, yMax, autoYScale} = props;
-    let {dataYMin, dataYMax} = this.state;
-    if (autoYScale && _isFinite(dataYMin) && _isFinite(dataYMax) && dataYMin !== 0 && dataYMax !== 0) {
-      yMin = dataYMin;
-      yMax = dataYMax;
+    let {start, end, width, sideWidth, yMin, yMax, autoYScale, tracks} = this.props;
+
+    if (autoYScale) {
+      let [allDataYMin, allDataYMax] = [null, null];
+      _map(this.state, ({dataYMin, dataYMax}) => {
+        if (allDataYMin === null || (dataYMin && dataYMin < allDataYMin))
+          allDataYMin = dataYMin;
+        if (allDataYMax === null || (dataYMax && dataYMax > allDataYMax))
+          allDataYMax = dataYMax;
+      });
+      if (_isFinite(allDataYMin) && _isFinite(allDataYMax)) {
+        yMin = allDataYMin;
+        yMax = allDataYMax;
+      }
     }
 
     if (width === 0)
@@ -97,8 +106,8 @@ let NumericalChannel = React.createClass({
     let offset = scale(0) - scale(start - 1 / 2);
 
     let initYAxisSpring = {
-      yMin: yMin,
-      yMax: yMax
+      yMin: _isFinite(yMin) ? yMin:null,
+      yMax: _isFinite(yMax) ? yMax:null
     };
     let yAxisSpring = {
       yMin: spring(initYAxisSpring.yMin),
@@ -122,7 +131,7 @@ let NumericalChannel = React.createClass({
         height={HEIGHT}
         sideComponent={<div className="side-name"> Uniqueness</div>}
         //Override component update
-        configComponent={<Controls {...props} componentUpdate={this.componentUpdate}/>}
+        configComponent={<Controls {...this.props} componentUpdate={this.componentUpdate}/>}
 
       >
         <svg className="numerical-summary" width={effWidth} height={height}>
@@ -132,12 +141,17 @@ let NumericalChannel = React.createClass({
               return <g>
                 <YScale min={yMin} max={yMax} width={effWidth} height={height}/>
                 <g
-                  transform={`translate(${offset}, ${height + (yMin * (height / (yMax - yMin)))}) scale(${stepWidth},${-(height / (yMax - yMin))})`}>
+                  transform={_isFinite(yMin) && _isFinite(yMax) ? `translate(${offset}, ${height + (yMin * (height / (yMax - yMin)))}) scale(${stepWidth},${-(height / (yMax - yMin))})` : ''}>
                   <rect className="origin-shifter" x={-effWidth} y={-height} width={2 * effWidth}
                         height={2 * height}/>
-                  <NumericalTrack blockStart={this.blockStart} blockEnd={this.blockEnd}
-                                  blockPixelWidth={blockPixelWidth}
-                                  onYLimitChange={this.handleYLimitChange} {...this.props}
+                  {tracks.map((track, index) => React.createElement(dynamicRequire(track.get('track')), Object.assign({
+                    key: index,
+                    blockStart: this.blockStart,
+                    blockEnd: this.blockEnd,
+                    blockPixelWidth: blockPixelWidth,
+                    onYLimitChange: (args) => this.handleYLimitChange(({...args, index}))
+                  }, this.props,
+                    track.get('props').toObject())))}
                   />
                 </g>
               </g>;

--- a/webapp/src/js/components/panoptes/genome/tracks/NumericalTrack.js
+++ b/webapp/src/js/components/panoptes/genome/tracks/NumericalTrack.js
@@ -97,10 +97,13 @@ let NumericalTrack = React.createClass({
             this.applyData(props);
             this.calculateYScale(props);
           })
+          .catch((err) => {
+            this.props.onChangeLoadStatus('DONE');
+            throw err;
+          })
           .catch(API.filterAborted)
           .catch(LRUCache.filterCancelled)
           .catch((error) => {
-            this.props.onChangeLoadStatus('DONE');
             ErrorReport(this.getFlux(), error.message, () => this.fetchData(props));
             this.setState({loadStatus: 'error'});
           })

--- a/webapp/src/js/components/panoptes/genome/tracks/ReferenceSequence.js
+++ b/webapp/src/js/components/panoptes/genome/tracks/ReferenceSequence.js
@@ -84,10 +84,13 @@ let ReferenceSequence = React.createClass({
             this.props.onChangeLoadStatus('DONE');
             this.applyData(data);
           })
+          .catch((err) => {
+            this.props.onChangeLoadStatus('DONE');
+            throw err;
+          })
           .catch(API.filterAborted)
           .catch(LRUCache.filterCancelled)
           .catch((error) => {
-            this.props.onChangeLoadStatus('DONE');
             ErrorReport(this.getFlux(), error.message, () => this.fetchData(props));
             this.setState({loadStatus: 'error'});
           })

--- a/webapp/src/js/components/ui/Pluralise.js
+++ b/webapp/src/js/components/ui/Pluralise.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const Pluralise = ({text, ord}) => <span>{text}{ord != 1 ? 's' : null}</span>;
+
+Pluralise.propTypes = {
+  text: React.PropTypes.string.isRequired,
+  ord: React.PropTypes.number.isRequired
+
+};
+
+export default Pluralise;

--- a/webapp/src/js/components/ui/TooltipEllipsis.js
+++ b/webapp/src/js/components/ui/TooltipEllipsis.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import PureRenderMixin from 'mixins/PureRenderMixin';
 
 import 'tooltip-ellipsis.scss';
@@ -11,7 +12,7 @@ let TooltipEllipsis = React.createClass({
   },
 
   componentDidUpdate() {
-    let e = React.findDOMNode(this.refs.element);
+    let e = ReactDOM.findDOMNode(this.refs.element);
     if (e.offsetWidth < e.scrollWidth)
       e.title = this.props.children;
   },

--- a/webapp/src/js/index.js
+++ b/webapp/src/js/index.js
@@ -30,7 +30,6 @@ import 'normalize.css';
 //https://github.com/zilverline/react-tap-event-plugin
 injectTapEventPlugin();
 
-
 function getAppState(location) {
   let match = /\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$/.exec(location);
   let defaultState = {

--- a/webapp/src/js/mixins/PureRenderWithComponentUpdateException.js
+++ b/webapp/src/js/mixins/PureRenderWithComponentUpdateException.js
@@ -8,7 +8,7 @@ let PureRenderWithComponentUpdateException = function(propsToCheck) {
     shouldComponentUpdate(nextProps, nextState) {
       let propsChanged = true;
       if (propsToCheck)
-        propsChanged = [propsToCheck].some((name) => !Immutable.is(this.props[name], nextProps[name]));
+        propsChanged = propsToCheck.some((name) => !Immutable.is(this.props[name], nextProps[name]));
       else
         propsChanged = !shallowEqualImmutable(
           Object.assign({}, this.props, {componentUpdate: false}),

--- a/webapp/src/js/panoptes/InitialConfig.js
+++ b/webapp/src/js/panoptes/InitialConfig.js
@@ -186,15 +186,17 @@ let parseSummaryValues = function() {
     let settings = {channelColor: 'rgb(0,0,180)'};
     if (summaryValue.settings)
       Object.assign(settings, JSON.parse(summaryValue.settings));
+
     summaryValue.settings = settings;
     if (summaryValue.tableid === '-') {
       summaryValue.tableid = '__reference__';
+    } else {
+      summaryValue.description = fetchedConfig.mapTableCatalog[summaryValue.tableid].propertiesMap[summaryValue.propid].description;
     }
     summaryValueMap[summaryValue.tableid] || (summaryValueMap[summaryValue.tableid] = {});
     summaryValueMap[summaryValue.tableid][summaryValue.propid] = summaryValue;
   });
   fetchedConfig.summaryValues = summaryValueMap;
-
 };
 
 let parseCustomProperties = function() {
@@ -251,18 +253,31 @@ let parseCustomProperties = function() {
 
     // Human friendly data type string
     prop.dispDataType = 'Text';
-    if (prop.settings.isCategorical)
+    prop.icon = 'font';
+    if (prop.settings.isCategorical) {
       prop.dispDataType = 'Categorical';
-    if (prop.isFloat)
+      prop.icon = 'bar-chart';
+    }
+    if (prop.isFloat) {
       prop.dispDataType = 'Value';
-    if (prop.isBoolean)
+      prop.icon = 'line-chart';
+    }
+    if (prop.isBoolean) {
       prop.dispDataType = 'Boolean';
-    if (prop.isDate)
+      prop.icon = 'check-square-o';
+    }
+    if (prop.isDate) {
       prop.dispDataType = 'Date';
-    if (prop.datatype == 'GeoLongitude')
+      prop.icon = 'calendar';
+    }
+    if (prop.datatype == 'GeoLongitude') {
       prop.dispDataType = 'Longitude';
-    if (prop.datatype == 'GeoLattitude')
+      prop.icon = 'globe';
+    }
+    if (prop.datatype == 'GeoLattitude') {
       prop.dispDataType = 'Latitude';
+      prop.icon = 'globe';
+    }
 
     //Assign property group
     if (prop.settings.GroupId)
@@ -558,9 +573,9 @@ let fetchInitialConfig = function() {
           });
         }
       });
-      parseSummaryValues();
     })
     .then(parseCustomProperties)
+    .then(parseSummaryValues)
     .then(() => {
     //parse2DProperties();
     //parseTableBasedSummaryValues();

--- a/webapp/src/js/panoptes/InitialConfig.js
+++ b/webapp/src/js/panoptes/InitialConfig.js
@@ -173,14 +173,17 @@ let augmentTableInfo = function(table) {
 let parseSummaryValues = function() {
   let summaryValueMap = {};
   fetchedConfig.summaryValues.forEach((summaryValue) => {
-    if (summaryValue.minval)
-      summaryValue.minval = parseFloat(summaryValue.minval);
-    else
-      summaryValue.minval = 0;
-    if (summaryValue.maxval)
-      summaryValue.maxval = parseFloat(summaryValue.maxval);
-    else
-      summaryValue.maxval = 0;
+    //I've tried to remove the need for this config, leaving the old here in case we needed it.
+    delete summaryValue.minval;
+    delete summaryValue.maxval;
+    //if (summaryValue.minval)
+    //  summaryValue.minval = parseFloat(summaryValue.minval);
+    //else
+    //  summaryValue.minval = 0;
+    //if (summaryValue.maxval)
+    //  summaryValue.maxval = parseFloat(summaryValue.maxval);
+    //else
+    //  summaryValue.maxval = 0;
     summaryValue.minblocksize = parseFloat(summaryValue.minblocksize);
     summaryValue.isCustom = true;
     let settings = {channelColor: 'rgb(0,0,180)'};

--- a/webapp/src/js/panoptes/InitialConfig.js
+++ b/webapp/src/js/panoptes/InitialConfig.js
@@ -1,5 +1,6 @@
 import _keys from 'lodash/keys';
 import _isString from 'lodash/isString';
+import _forEach from 'lodash/forEach';
 import API from 'panoptes/API';
 import SQL from 'panoptes/SQL';
 import attrMap from 'util/AttrMap';
@@ -30,11 +31,27 @@ function caseChange(config) {
       value.forEach((ele) => arr.push(caseChange(ele)));
       value = arr;
     } else if (
+
       typeof value === 'object' &&
       key !== 'propertiesMap' &&
       key !== 'propertyGroups' &&
-      key !== 'chromosomes') {
+      key !== 'chromosomes' &&
+      key !== 'summaryValues'
+    ) {
       value = caseChange(value);
+    }
+    //Annoyingly we have to have these exceptions for config defined names - shouldn't be a problem when this is made server side.
+    if (
+      typeof value === 'object' &&
+      key === 'summaryValues'
+    ) {
+      let out = {};
+      _forEach(value, (val, key) => {
+        let out2 = {};
+        _forEach(val, (val2, key2) => out2[key2] = caseChange(val2));
+        out[key] = out2;
+      });
+      value = out;
     }
     out[destKey] = value;
   });

--- a/webapp/src/js/stores/SessionStore.js
+++ b/webapp/src/js/stores/SessionStore.js
@@ -16,39 +16,55 @@ let SessionStore = Fluxxor.createStore({
       this.state = Immutable.Map();
 
 
+    //this.state = this.state.mergeDeep(Immutable.fromJS({
+    //  components: {
+    //    'TEST': {
+    //      component: 'containers/DataTableWithActions',
+    //      props: {
+    //        table: 'variants'
+    //      }
+    //    }
+    //  },
+    //  tabs: {
+    //    components: ['TEST'],
+    //    selectedTab: 'TEST'
+    //  },
+    //  popups: {
+    //    components: [],
+    //    state: {}
+    //  },
+    //  modal: {}
+    //}));
+
+
     this.state = this.state.mergeDeep(Immutable.fromJS({
       components: {
         'TEST': {
-          component: 'containers/DataTableWithActions',
-          props: {
-            table: 'variants'
-          }
-        }
-      },
-      tabs: {
-        components: ['TEST'],
-        selectedTab: 'TEST'
-      },
-      popups: {
-        components: [],
-        state: {}
-      },
-      modal: {}
-    }));
-
-
-    /*
-    this.state = this.state.mergeDeep(Immutable.fromJS({
-      components: {
-        'TEST': {
-          component: "containers/GenomeBrowserWithActions",
+          component: 'containers/GenomeBrowserWithActions',
           props: {
             chromosome: 'Pf3D7_01_v3',
-            components: {
+            channels: {
               test: {
-                component: 'NumericalSummary',
-                props: {}
-              },
+                channel: 'NumericalChannel',
+                props: {
+                  tracks: [{
+                    track: 'NumericalSummaryTrack',
+                    props: {
+                      group: '__reference__',
+                      track: 'Uniqueness'
+                    }
+                  },
+                    {
+                      track: 'NumericalSummaryTrack',
+                      props: {
+                        group: 'variants',
+                        track: 'Value_three'
+                      }
+                    }
+
+                  ]
+                }
+              }
             }
           }
         }
@@ -63,7 +79,6 @@ let SessionStore = Fluxxor.createStore({
       },
       modal: {}
     }));
-    */
 
 
 


### PR DESCRIPTION
These patches add a mechanism for generically adding channels to the genome browser, and let a numerical channel hold many tracks. Initially channels have a single track - the next step is to add the UI for adding a track to a channel, then add more channel types for categorical, per-sample genotypes etc.

This also removes the need for max/min config for summaries.