### PR TITLE
Display quote marks for empty string values in query string

### DIFF
--- a/webapp/src/js/panoptes/SQL.js
+++ b/webapp/src/js/panoptes/SQL.js
@@ -258,7 +258,9 @@ SQL.WhereClause.CompareFixed = function(icolname, icomptype, ivalue) {
   that.CompValue = ivalue;
 
   that.toQueryDisplayString = function(queryData) {
-    return queryData.fieldInfoMap[that.ColName].name + ' ' + that.type + ' ' + queryData.fieldInfoMap[that.ColName].toDisplayString(that.CompValue);
+    let displayValue = queryData.fieldInfoMap[that.ColName].toDisplayString(that.CompValue);
+    if (displayValue === '') displayValue = '""';
+    return queryData.fieldInfoMap[that.ColName].name + ' ' + that.type + ' ' + displayValue;
   };
 
   return that;


### PR DESCRIPTION
Addresses #440

I expect curly quotes (e.g. &ldquo;&rdquo; or &lsquo;&rsquo;) would look better, but I haven't worked out how to render them.

Alternatives: '' or even [blank]