### PR TITLE
Pivot Table component

### DIFF
--- a/webapp/src/js/components/containers/DataTableWithActions.js
+++ b/webapp/src/js/components/containers/DataTableWithActions.js
@@ -102,7 +102,6 @@ let DataTableWithActions = React.createClass({
   },
 
   handleQueryPick(query) {
-    this.getFlux().actions.session.modalClose();
     this.props.componentUpdate({query: query});
   },
 
@@ -309,7 +308,7 @@ let DataTableWithActions = React.createClass({
         {searchGUI}
         <FlatButton label="Pivot Table"
                     primary={true}
-                    onClick={() => this.flux.actions.session.tabOpen('containers/PivotTableWithActions', {table}, false)}
+                    onClick={() => this.flux.actions.session.tabOpen('containers/PivotTableWithActions', {table}, true)}
                     icon={<Icon fixedWidth={true} name="table" />}
         />
       </div>

--- a/webapp/src/js/components/containers/DataTableWithActions.js
+++ b/webapp/src/js/components/containers/DataTableWithActions.js
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import Immutable from 'immutable';
 import ImmutablePropTypes from 'react-immutable-proptypes';
-import LZString from 'lz-string';
 import Sidebar from 'react-sidebar';
 import scrollbarSize from 'scrollbar-size';
 
@@ -31,6 +30,7 @@ import QueryString from 'panoptes/QueryString';
 import SQL from 'panoptes/SQL';
 import DataDownloader from 'utils/DataDownloader';
 import HTMLWithComponents from 'panoptes/HTMLWithComponents';
+import FilterButton from 'panoptes/FilterButton';
 
 let DataTableWithActions = React.createClass({
   mixins: [PureRenderMixin, FluxMixin, ConfigMixin],
@@ -283,25 +283,12 @@ let DataTableWithActions = React.createClass({
 
     let dataTableQuery = this.createDataTableQuery();
 
-    let filterButtonLabel = 'Change Filter';
-    let decodedQuery = SQL.WhereClause.decode(query);
-    if (!query || decodedQuery.isTrivial) filterButtonLabel = 'Add Filter';
-
     let descriptionWithHTML = <HTMLWithComponents>{description}</HTMLWithComponents>;
 
     let sidebarContent = (
       <div className="sidebar">
         <SidebarHeader icon={this.icon()} description={descriptionWithHTML}/>
-        <FlatButton label={filterButtonLabel}
-                    primary={true}
-                    onClick={() => actions.session.modalOpen('containers/QueryPicker',
-                      {
-                        table: table,
-                        initialQuery: query,
-                        onPick: this.handleQueryPick
-                      })}
-                      icon={<Icon fixedWidth={true} name="filter" />}
-        />
+        <FilterButton table={table} query={query} onPick={this.handleQueryPick}/>
         <FlatButton label="Add/Remove Columns"
                     primary={true}
                     onClick={() => actions.session.modalOpen('containers/GroupedItemPicker',
@@ -320,6 +307,11 @@ let DataTableWithActions = React.createClass({
                     icon={<Icon fixedWidth={true} name="download" />}
         />
         {searchGUI}
+        <FlatButton label="Pivot Table"
+                    primary={true}
+                    onClick={() => this.flux.actions.session.tabOpen('containers/PivotTableWithActions', {table}, false)}
+                    icon={<Icon fixedWidth={true} name="table" />}
+        />
       </div>
     );
 

--- a/webapp/src/js/components/containers/MapWithActions.js
+++ b/webapp/src/js/components/containers/MapWithActions.js
@@ -21,6 +21,7 @@ import {FlatButton} from 'material-ui';
 // Panoptes UI
 import SidebarHeader from 'ui/SidebarHeader';
 import Icon from 'ui/Icon';
+import FilterButton from 'panoptes/FilterButton';
 
 // Panoptes
 import SQL from 'panoptes/SQL';
@@ -64,7 +65,6 @@ let MapWithActions = React.createClass({
   },
 
   handleQueryPick(query) {
-    this.getFlux().actions.session.modalClose();
     this.props.componentUpdate({query: query});
   },
 
@@ -101,19 +101,6 @@ let MapWithActions = React.createClass({
       });
     }
 
-    let filterButtonLabel = 'Change Filter';
-    let decodedQuery = SQL.WhereClause.decode(query);
-    let clearFilterButton = null;
-    if (!query || decodedQuery.isTrivial) {
-      filterButtonLabel = 'Add Filter';
-    } else if (table) {
-      clearFilterButton = <FlatButton
-                                label="Clear Filter"
-                                primary={true}
-                                onClick={() => componentUpdate({query: SQL.nullQuery})}
-                              />;
-    }
-
     let sidebarContent = (
       <div className="sidebar map-sidebar">
         <SidebarHeader icon={this.icon()} description="Something here"/>
@@ -125,16 +112,8 @@ let MapWithActions = React.createClass({
             onChange={this.handleChangeTable}
             options={tableOptions}
           />
-          {table ? <FlatButton label={filterButtonLabel}
-                               primary={true}
-                               onClick={() => actions.session.modalOpen('containers/QueryPicker',
-                                 {
-                                   table: table,
-                                   initialQuery: query,
-                                   onPick: this.handleQueryPick
-                                 })}/>
+          {table ? <FilterButton table={table} query={query} onPick={this.handleQueryPick}/>
             : null}
-          {clearFilterButton}
           {table ?
               <SelectField value={this.config.tablesById[table].propertiesById[column] ? column : null}
                            autoWidth={true}

--- a/webapp/src/js/components/containers/PivotTableWithActions.js
+++ b/webapp/src/js/components/containers/PivotTableWithActions.js
@@ -1,0 +1,109 @@
+import React from 'react';
+import scrollbarSize from 'scrollbar-size';
+import {treeTypes} from 'phylocanvas';
+import titleCase from 'title-case';
+import Sidebar from 'react-sidebar';
+
+// Lodash
+import _map from 'lodash/map';
+import _has from 'lodash/has';
+import _filter from 'lodash/filter';
+import _keys from 'lodash/keys';
+
+// Mixins
+import PureRenderMixin from 'mixins/PureRenderMixin';
+import ConfigMixin from 'mixins/ConfigMixin';
+import FluxMixin from 'mixins/FluxMixin';
+
+// Material U(I
+import {RaisedButton} from 'material-ui';
+
+// Panoptes UI
+import SidebarHeader from 'ui/SidebarHeader';
+import Icon from 'ui/Icon';
+
+// Panoptes
+import PivotTableView from 'panoptes/PivotTableView';
+import PropertySelector from 'panoptes/PropertySelector';
+import FilterButton from 'panoptes/FilterButton';
+import SQL from 'panoptes/SQL';
+import QueryString from 'panoptes/QueryString';
+
+
+let PivotTableWithActions = React.createClass({
+  mixins: [
+    PureRenderMixin,
+    FluxMixin,
+    ConfigMixin
+  ],
+
+  propTypes: {
+    componentUpdate: React.PropTypes.func.isRequired,
+    title: React.PropTypes.string,
+    sidebar: React.PropTypes.bool,
+    table: React.PropTypes.string,
+    query: React.PropTypes.string,
+    columnProperty: React.PropTypes.string,
+    rowProperty: React.PropTypes.string,
+  },
+
+  getDefaultProps() {
+    return {
+      query: SQL.nullQuery,
+      componentUpdate: null,
+      sidebar: true
+    };
+  },
+
+  icon() {
+    return 'table';
+  },
+
+  title() {
+    return this.props.title || `Pivot ${this.tableConfig().namePlural}`;
+  },
+
+  render() {
+    const {sidebar, table, query, columnProperty, rowProperty, componentUpdate} = this.props;
+
+    let sidebarContent = (
+      <div className="sidebar pivot-sidebar">
+        <SidebarHeader icon={this.icon()} description={`Summary and aggregates of the ${this.tableConfig().namePlural} table`}/>
+        <div className="pivot-controls vertical stack">
+          <FilterButton table={table} query={query} onPick={(query) => this.props.componentUpdate({query})}/>
+          <PropertySelector table={table}
+                            key="columnProperty"
+                            value={this.config.tablesById[table].propertiesById[columnProperty] ? columnProperty : null}
+                            label="Column"
+                            onSelect={(v) => componentUpdate({columnProperty: v})}/>
+          <PropertySelector table={table}
+                            key="rowProperty"
+                            value={this.config.tablesById[table].propertiesById[rowProperty] ? rowProperty : null}
+                            label="Row"
+                            onSelect={(v) => componentUpdate({rowProperty: v})}/>
+        </div>
+      </div>
+    );
+    return (
+      <Sidebar
+        docked={sidebar}
+        styles={{sidebar: {paddingRight: `${scrollbarSize()}px`}}}
+        sidebar={sidebarContent}>
+        <div className="vertical stack">
+          <div className="top-bar">
+            <Icon className="pointer icon"
+                  name={sidebar ? 'arrows-h' : 'bars'}
+                  title={sidebar ? 'Expand' : 'Sidebar'}
+                  onClick={() => componentUpdate({sidebar: !sidebar})}/>
+            <span className="text"><QueryString prepend="Filter:" table={table} query={query}/></span>
+          </div>
+          <div className="grow">
+            {(columnProperty || rowProperty) ? <PivotTableView {...this.props}/> : "Pick properties"}
+          </div>
+        </div>
+      </Sidebar>
+    );
+  }
+});
+
+module.exports = PivotTableWithActions;

--- a/webapp/src/js/components/containers/PivotTableWithActions.js
+++ b/webapp/src/js/components/containers/PivotTableWithActions.js
@@ -75,11 +75,13 @@ let PivotTableWithActions = React.createClass({
                             key="columnProperty"
                             value={this.config.tablesById[table].propertiesById[columnProperty] ? columnProperty : null}
                             label="Column"
+                            filter={(prop) => prop.isCategorical || prop.isBoolean || prop.isText}
                             onSelect={(v) => componentUpdate({columnProperty: v})}/>
           <PropertySelector table={table}
                             key="rowProperty"
                             value={this.config.tablesById[table].propertiesById[rowProperty] ? rowProperty : null}
                             label="Row"
+                            filter={(prop) => prop.isCategorical || prop.isBoolean || prop.isText}
                             onSelect={(v) => componentUpdate({rowProperty: v})}/>
         </div>
       </div>

--- a/webapp/src/js/components/containers/PlotWithActions.js
+++ b/webapp/src/js/components/containers/PlotWithActions.js
@@ -13,7 +13,6 @@ import ConfigMixin from 'mixins/ConfigMixin';
 import FluxMixin from 'mixins/FluxMixin';
 
 // Material UI
-import {FlatButton} from 'material-ui';
 import SelectField from 'material-ui/SelectField';
 import MenuItem from 'material-ui/MenuItem';
 
@@ -28,6 +27,7 @@ import PlotContainer from 'containers/PlotContainer';
 import QueryString from 'panoptes/QueryString';
 import {plotTypes, allDimensions} from 'panoptes/plotTypes';
 import SelectFieldWithNativeFallback from 'panoptes/SelectFieldWithNativeFallback';
+import FilterButton from 'panoptes/FilterButton';
 
 import "plot.scss";
 
@@ -68,7 +68,6 @@ let PlotWithActions = React.createClass({
   },
 
   handleQueryPick(query) {
-    this.getFlux().actions.session.modalClose();
     this.props.componentUpdate({query: query});
   },
 
@@ -78,7 +77,6 @@ let PlotWithActions = React.createClass({
 
   render() {
     let {sidebar, table, query, plotType, componentUpdate} = this.props;
-    const actions = this.getFlux().actions;
 
     let tableOptions = _map(this.config.visibleTables, (table) => ({
       value: table.id,
@@ -86,18 +84,7 @@ let PlotWithActions = React.createClass({
       label: table.capNamePlural
     }));
 
-    let filterButtonLabel = 'Change Filter';
-    let decodedQuery = SQL.WhereClause.decode(query);
-    let clearFilterButton = null;
-    if (!query || decodedQuery.isTrivial) {
-      filterButtonLabel = 'Add Filter';
-    } else if (table) {
-      clearFilterButton = <FlatButton
-                                label="Clear Filter"
-                                primary={true}
-                                onClick={() => componentUpdate({query: SQL.nullQuery})}
-                              />;
-    }
+
 
     let sidebarContent = (
       <div className="sidebar plot-sidebar">
@@ -110,16 +97,8 @@ let PlotWithActions = React.createClass({
             onChange={this.handleChangeTable}
             options={tableOptions}
           />
-          {table ? <FlatButton label={filterButtonLabel}
-                      primary={true}
-                      onClick={() => actions.session.modalOpen('containers/QueryPicker',
-                        {
-                          table: table,
-                          initialQuery: query,
-                          onPick: this.handleQueryPick
-                        })}/>
+          {table ? <FilterButton table={table} query={query} onPick={this.handleQueryPick}/>
             : null}
-          {clearFilterButton}
           <SelectField value={plotType}
                        autoWidth={true}
                        floatingLabelText="Plot Type:"

--- a/webapp/src/js/components/containers/PlotWithActions.js
+++ b/webapp/src/js/components/containers/PlotWithActions.js
@@ -1,15 +1,11 @@
 import React from 'react';
-import Immutable from 'immutable';
-import ImmutablePropTypes from 'react-immutable-proptypes';
 import titleCase from 'title-case';
 import scrollbarSize from 'scrollbar-size';
 import Sidebar from 'react-sidebar';
 
 // Lodash
 import _map from 'lodash/map';
-import _each from 'lodash/map';
 import _reduce from 'lodash/reduce';
-import _filter from 'lodash/filter';
 
 // Mixins
 import PureRenderMixin from 'mixins/PureRenderMixin';
@@ -17,7 +13,6 @@ import ConfigMixin from 'mixins/ConfigMixin';
 import FluxMixin from 'mixins/FluxMixin';
 
 // Material UI
-import Divider from 'material-ui/Divider';
 import {FlatButton} from 'material-ui';
 import SelectField from 'material-ui/SelectField';
 import MenuItem from 'material-ui/MenuItem';
@@ -25,6 +20,7 @@ import MenuItem from 'material-ui/MenuItem';
 // Panoptes UI
 import SidebarHeader from 'ui/SidebarHeader';
 import Icon from 'ui/Icon';
+import PropertySelector from 'panoptes/PropertySelector'
 
 // Panoptes
 import SQL from 'panoptes/SQL';
@@ -90,23 +86,6 @@ let PlotWithActions = React.createClass({
       label: table.capNamePlural
     }));
 
-    let propertyMenu = [];
-    let i = 0;
-    if (table) {
-      const propertyGroups = this.config.tablesById[table].propertyGroups;
-      _each(propertyGroups, (group) => {
-        if (propertyMenu.length) {
-          propertyMenu.push(<Divider key={i++}/>);
-        }
-        let {id, name} = group;
-        propertyMenu.push(<MenuItem disabled value={id} key={id} primaryText={name}/>);
-        _each(group.properties, (property) => {
-          let {id, name} = property;
-          propertyMenu.push(<MenuItem value={id} key={id} primaryText={name}/>);
-        });
-      });
-    }
-
     let filterButtonLabel = 'Change Filter';
     let decodedQuery = SQL.WhereClause.decode(query);
     let clearFilterButton = null;
@@ -150,13 +129,11 @@ let PlotWithActions = React.createClass({
           </SelectField>
           {table && plotType ?
             _map(plotTypes[plotType].dimensions, (dimension) =>
-              <SelectField value={this.config.tablesById[table].propertiesById[this.props[dimension]] ? this.props[dimension] : null}
-                           key={dimension}
-                           autoWidth={true}
-                           floatingLabelText={titleCase(dimension)}
-                           onChange={(e, i, v) => componentUpdate({[dimension]: v})}>
-                {propertyMenu}
-              </SelectField>
+              <PropertySelector table={table}
+                                key={dimension}
+                                value={this.config.tablesById[table].propertiesById[this.props[dimension]] ? this.props[dimension] : null}
+                                label={titleCase(dimension)}
+                                onSelect={(v) => componentUpdate({[dimension]: v})}/>
             )
             : null }
         </div>

--- a/webapp/src/js/components/panoptes/FilterButton.js
+++ b/webapp/src/js/components/panoptes/FilterButton.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import PureRenderMixin from 'mixins/PureRenderMixin';
+import {FlatButton} from 'material-ui';
+import SQL from 'panoptes/SQL';
+import FluxMixin from 'mixins/FluxMixin';
+import Icon from 'ui/Icon';
+
+const componentTranslation = {
+  ItemMap: 'containers/MapWithActions',
+  Tree: 'containers/TreeWithActions',
+  Plot: 'containers/PlotWithActions'
+};
+
+let FilterButton = React.createClass({
+  mixins: [
+    PureRenderMixin,
+    FluxMixin,
+  ],
+
+  propTypes: {
+    query: React.PropTypes.string,
+    table: React.PropTypes.string.isRequired,
+    onPick: React.PropTypes.func.isRequired,
+  },
+
+  getDefaultProps() {
+    return {
+      query: SQL.nullQuery,
+    };
+  },
+
+  handlePick(query) {
+    this.getFlux().actions.session.modalClose();
+    this.props.onPick(query)
+  },
+
+  render() {
+    const {query, table} = this.props;
+    let decodedQuery = SQL.WhereClause.decode(query);
+
+    return <div>
+      <FlatButton label={decodedQuery.isTrivial ? 'Add Filter' : 'Change Filter'}
+                  primary={true}
+                  onClick={() => this.getFlux().actions.session.modalOpen('containers/QueryPicker',
+                    {
+                      table,
+                      initialQuery: query,
+                      onPick: this.handlePick
+                    })}
+                  icon={<Icon fixedWidth={true} name="filter" />}
+      />
+      {decodedQuery.isTrivial ? null :
+        <FlatButton
+          label="Clear Filter"
+          primary={true}
+          onClick={() => {
+            this.handlePick(SQL.nullQuery)
+          }}
+          icon={<span className={'fa-stack'}><Icon style={{position: 'absolute', color:'rgb(153, 200, 236)'}} name={'filter'} stack={'1x'} /><Icon style={{position: 'absolute', fontSize: '2em', color: '#2196f3'}} name={'ban'} stack={'2x'} /></span>}
+        />
+      }
+
+    </div>
+  }
+
+});
+
+export default FilterButton;

--- a/webapp/src/js/components/panoptes/PivotTableView.js
+++ b/webapp/src/js/components/panoptes/PivotTableView.js
@@ -1,0 +1,135 @@
+import React from 'react';
+import Immutable from 'immutable';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import classNames from 'classnames';
+import Color from 'color';
+
+
+// Mixins
+import PureRenderMixin from 'mixins/PureRenderMixin';
+import FluxMixin from 'mixins/FluxMixin';
+import ConfigMixin from 'mixins/ConfigMixin';
+import DataFetcherMixin from 'mixins/DataFetcherMixin';
+
+import {Table, Column} from 'fixed-data-table';
+import 'fixed-data-table/dist/fixed-data-table.css';
+
+// Panoptes components
+import API from 'panoptes/API';
+import LRUCache from 'util/LRUCache';
+import ErrorReport from 'panoptes/ErrorReporter';
+import SQL from 'panoptes/SQL';
+import PropertyCell from 'panoptes/PropertyCell';
+import PropertyHeader from 'panoptes/PropertyHeader';
+
+// UI components
+import Loading from 'ui/Loading';
+import Icon from 'ui/Icon';
+import DetectResize from 'utils/DetectResize';
+
+// Constants in this component
+const MAX_COLOR = Color('#44aafb');
+const ROW_HEIGHT = 30;
+const HEADER_HEIGHT = 50;
+const SCROLLBAR_HEIGHT = 15;
+
+let DataTableView = React.createClass({
+  mixins: [
+    PureRenderMixin,
+    FluxMixin,
+    ConfigMixin,
+    DataFetcherMixin('table', 'query', 'columnProperty', 'rowProperty')
+  ],
+
+  propTypes: {
+    table: React.PropTypes.string.isRequired,
+    query: React.PropTypes.string,
+    columnProperty: React.PropTypes.string,
+    rowProperty: React.PropTypes.string,
+
+  },
+
+
+  getDefaultProps() {
+    return {
+      query: SQL.nullQuery,
+    };
+  },
+
+  getInitialState() {
+    return {
+      rows: [],
+      loadStatus: 'loaded',
+      width: 0,
+      height: 0,
+    };
+  },
+
+  //Called by DataFetcherMixin
+  fetchData(props, requestContext) {
+    let {table, query, columnProperty, rowProperty} = props;
+    let tableConfig = this.config.tablesById[table];
+    let columnspec = {
+      'count(*)': 'IN'  //Possible encoding values are at ConfigStore:265
+    };
+    let groupby = [];
+    if (columnProperty) {
+      columnspec[columnProperty] = tableConfig.propertiesById[columnProperty].defaultDisplayEncoding;
+      groupby.push(columnProperty);
+    }
+    if (rowProperty) {
+      columnspec[rowProperty] = tableConfig.propertiesById[rowProperty].defaultDisplayEncoding;
+      groupby.push(rowProperty);
+    }
+    this.setState({loadStatus: 'loading'});
+
+    let pageQueryAPIargs = {
+      database: this.config.dataset,
+      table: tableConfig.fetchTableName,
+      columns: columnspec,
+      query: query,
+      groupby
+    };
+
+    requestContext.request((componentCancellation) =>
+        LRUCache.get(
+          'pageQuery' + JSON.stringify(pageQueryAPIargs),
+          (cacheCancellation) =>
+            API.pageQuery({cancellation: cacheCancellation, ...pageQueryAPIargs}),
+          componentCancellation
+        ),
+    )
+    .then((rows) => {
+      this.setState({
+        loadStatus: 'loaded',
+        rows: rows,
+      });
+    })
+    .catch(API.filterAborted)
+    .catch(LRUCache.filterCancelled)
+    // .catch((xhr) => {
+    //   ErrorReport(this.getFlux(), API.errorMessage(xhr), () => this.fetchData(this.props));
+    //   this.setState({loadStatus: 'error'});
+    // });
+    .done()
+  },
+
+  handleResize(size) {
+    this.setState(size);
+  },
+
+  render() {
+    let {className, columnProperty, rowProperty} = this.props;
+    let {loadStatus, rows, width, height} = this.state;
+    let tableConfig = this.config.tablesById[this.props.table];
+    if (!tableConfig) {
+      console.log(`Table ${this.props.table} doesn't exist'`);
+      return null;
+    }
+    return <div>{JSON.stringify(rows)}</div>;
+
+  }
+
+});
+
+module.exports = DataTableView;

--- a/webapp/src/js/components/panoptes/genome/tracks/PerRowIndicatorChannel.js
+++ b/webapp/src/js/components/panoptes/genome/tracks/PerRowIndicatorChannel.js
@@ -20,7 +20,7 @@ import API from 'panoptes/API';
 import LRUCache from 'util/LRUCache';
 
 import ChannelWithConfigDrawer from 'panoptes/genome/tracks/ChannelWithConfigDrawer';
-import FlatButton from 'material-ui/FlatButton';
+import FilterButton from 'panoptes/FilterButton';
 
 import 'hidpi-canvas';
 import {propertyColour, categoryColours} from 'util/Colours';
@@ -319,29 +319,16 @@ const PerRowIndicatorControls = React.createClass({
   ],
 
   handleQueryPick(query) {
-    this.getFlux().actions.session.modalClose();
     this.redirectedProps.componentUpdate({query});
   },
 
   render() {
     let {table, query, colourProperty} = this.props;
-    let actions = this.getFlux().actions;
-
-    let filterButtonLabel = 'Change Filter';
-    let decodedQuery = SQL.WhereClause.decode(query);
-    if (!query || decodedQuery.isTrivial) filterButtonLabel = 'Add Filter';
 
     return (
       <div className="channel-controls">
         <div className="control">
-          <FlatButton label={filterButtonLabel}
-                      primary={true}
-                      onClick={() => actions.session.modalOpen('containers/QueryPicker',
-                        {
-                          table: table,
-                          initialQuery: query,
-                          onPick: this.handleQueryPick
-                        })}/>
+          <FilterButton table={table} query={query} onPick={this.handleQueryPick}/>
         </div>
         <div className="control">
           <div className="label">Colour By:</div>

--- a/webapp/src/js/components/panoptes/genome/tracks/PerRowNumericalChannel.js
+++ b/webapp/src/js/components/panoptes/genome/tracks/PerRowNumericalChannel.js
@@ -364,29 +364,16 @@ let PerRowNumericalTrackControls = React.createClass({
   ],
 
   handleQueryPick(query) {
-    this.getFlux().actions.session.modalClose();
     this.redirectedProps.componentUpdate({query});
   },
 
   render() {
     let {interpolation, tension, autoYScale, yMin, yMax, query, table, colourProperty} = this.props;
-    let actions = this.getFlux().actions;
-
-    let filterButtonLabel = 'Change Filter';
-    let decodedQuery = SQL.WhereClause.decode(query);
-    if (!query || decodedQuery.isTrivial) filterButtonLabel = 'Add Filter';
 
     return (
       <div className="channel-controls">
         <div className="control">
-          <FlatButton label={filterButtonLabel}
-                      primary={true}
-                      onClick={() => actions.session.modalOpen('containers/QueryPicker',
-                        {
-                          table: table,
-                          initialQuery: query,
-                          onPick: this.handleQueryPick
-                        })}/>
+          <FilterButton table={table} query={query} onPick={this.handleQueryPick}/>
         </div>
         <div className="control">
           <div className="label">Colour By:</div>

--- a/webapp/src/js/panoptes/API.js
+++ b/webapp/src/js/panoptes/API.js
@@ -92,6 +92,7 @@ function pageQuery(options) {
   let defaults = {
     query: SQL.nullQuery,
     order: null,
+    groupby: null,
     ascending: true,
     count: false,
     start: 0,
@@ -99,7 +100,7 @@ function pageQuery(options) {
     distinct: false,
     transpose: true
   };
-  let {database, table, columns, query, order,
+  let {database, table, columns, query, order, groupby,
     ascending, count, start, stop, distinct, transpose} = {...defaults, ...options};
 
   let collist = '';
@@ -108,15 +109,18 @@ function pageQuery(options) {
     collist += encoding + id;
   });
   let args = options.cancellation ? {cancellation: options.cancellation} : {};
+  let params = {};
+  params = order ? {order, ...params} : params;
+  params = groupby ? {groupby: groupby.join('~'), ...params} : params;
   return requestJSON({
     ...args,
     params: {
+      ...params,
       datatype: 'pageqry',
-      database: database,
+      database,
       tbname: table,
       qry: query,
       collist: LZString.compressToEncodedURIComponent(collist),
-      order: order,
       sortreverse: ascending ? '0' : '1',
       needtotalcount: count ? '1' : '0',
       limit: `${start}~${stop}`,

--- a/webapp/src/js/panoptes/PropertySelector.js
+++ b/webapp/src/js/panoptes/PropertySelector.js
@@ -5,7 +5,8 @@ import FluxMixin from 'mixins/FluxMixin';
 import Divider from 'material-ui/Divider';
 import SelectField from 'material-ui/SelectField';
 import MenuItem from 'material-ui/MenuItem';
-import _each from 'lodash/map';
+import _each from 'lodash/each';
+import _filter from 'lodash/filter';
 
 
 const PropertySelector = React.createClass({
@@ -26,23 +27,32 @@ const PropertySelector = React.createClass({
   propTypes: {
     table: React.PropTypes.string,
     value: React.PropTypes.string,
+    filter: React.PropTypes.func,
     onSelect: React.PropTypes.func
   },
 
+  getDefaultProps() {
+    return {
+      filter: () => true
+    };
+  },
+
   render() {
-    const { table, value, label} = this.props;
+    const { table, value, label, filter} = this.props;
 
     let propertyMenu = [];
     let i = 0;
     if (table) {
       const propertyGroups = this.config.tablesById[table].propertyGroups;
       _each(propertyGroups, (group) => {
-        if (propertyMenu.length) {
+        let filteredProps = _filter(group.properties, filter);
+        if (filteredProps.length == 0) return;
+        if (propertyMenu.length ) {
           propertyMenu.push(<Divider key={i++}/>);
         }
         let {id, name} = group;
         propertyMenu.push(<MenuItem disabled value={id} key={id} primaryText={name}/>);
-        _each(group.properties, (property) => {
+        _each(filteredProps, (property) => {
           let {id, name} = property;
           propertyMenu.push(<MenuItem value={id} key={id} primaryText={name}/>);
         });

--- a/webapp/src/js/panoptes/PropertySelector.js
+++ b/webapp/src/js/panoptes/PropertySelector.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import ConfigMixin from 'mixins/ConfigMixin';
 import PureRenderWithRedirectedProps from 'mixins/PureRenderWithRedirectedProps';
-import DropDownMenu from 'material-ui/DropDownMenu';
-import MenuItem from 'material-ui/MenuItem';
 import FluxMixin from 'mixins/FluxMixin';
+import Divider from 'material-ui/Divider';
+import SelectField from 'material-ui/SelectField';
+import MenuItem from 'material-ui/MenuItem';
+import _each from 'lodash/map';
 
 
 const PropertySelector = React.createClass({
@@ -28,15 +30,32 @@ const PropertySelector = React.createClass({
   },
 
   render() {
-    const { table, value } = this.props;
+    const { table, value, label} = this.props;
+
+    let propertyMenu = [];
+    let i = 0;
+    if (table) {
+      const propertyGroups = this.config.tablesById[table].propertyGroups;
+      _each(propertyGroups, (group) => {
+        if (propertyMenu.length) {
+          propertyMenu.push(<Divider key={i++}/>);
+        }
+        let {id, name} = group;
+        propertyMenu.push(<MenuItem disabled value={id} key={id} primaryText={name}/>);
+        _each(group.properties, (property) => {
+          let {id, name} = property;
+          propertyMenu.push(<MenuItem value={id} key={id} primaryText={name}/>);
+        });
+      });
+    }
+
     return (
-      <DropDownMenu className="dropdown"
-                  value={value}
-                  onChange={(e, i, v) => this.redirectedProps.onSelect(v)}>
-        <MenuItem key="__none__" value={undefined} primaryText="None"/>
-        {this.config.tablesById[table].properties.map((property) =>
-          <MenuItem key={property.id} value={property.id} primaryText={property.name}/>)}
-      </DropDownMenu>
+    <SelectField value={value}
+                 autoWidth={true}
+                 floatingLabelText={label}
+                 onChange={(e, i, v) => this.redirectedProps.onSelect(v)}>
+      {propertyMenu}
+    </SelectField>
     );
   }
 });

--- a/webapp/src/styles/genomebrowser.scss
+++ b/webapp/src/styles/genomebrowser.scss
@@ -195,6 +195,7 @@
           justify-content: flex-start;
           .label {
             padding-left: 10px;
+            padding-right: 5px;
           }
           .dropdown {
             top: -4px;


### PR DESCRIPTION
This PR adds simple pivot tables to Panoptes. WIth this you can pick two non-numeric columns of data and a table showing counts of rows with each combination of the column values is shown. A filter can be applied to the table, to only count the passing rows. 

This is a simple proof of concept - it could be extended to %rows, avg value of a third column per cell, additional pivot columns (each column/row of the table can be for a pair of values)
![screenshot-32](https://cloud.githubusercontent.com/assets/8552/17042080/b6b371d6-4fa2-11e6-8515-9a78eaa67d52.png)

This PR also includes factoring out the filter button app wide.

NB You will need to rebuild (./scripts/build.sh DEV) to get needed DQXServer changes.