### PR TITLE
Show subsize content. Style warning messages.

### DIFF
--- a/webapp/src/index.html
+++ b/webapp/src/index.html
@@ -5,19 +5,23 @@
   <title>Panoptes</title>
   <link href='http://fonts.googleapis.com/css?family=Roboto:400,700,700italic' rel='stylesheet' type='text/css'>
   <style>
+    body {
+      margin: 0;
+    }
     #JSwarning {
-       margin: 20px;
+       padding: 20px;
+       font-family: sans-serif;
+       border-bottom: 4px solid #3d8bd5;
     }
     #widthWarning {
        display: none;
-       margin: 20px;
+       padding: 20px;
+       font-family: sans-serif;
+       border-bottom: 4px solid #3d8bd5;
     }
     @media only screen and (max-width: 749px) {
       #widthWarning {
          display: block;
-      }
-      #main {
-         display: none;
       }
     }
   </style>


### PR DESCRIPTION
Related to #379 

The idea of having a fixed-size scrollable layout at widths below 750px seems to be hampered by existing styles, resulting in awkward collapsing, but we might yet find the right magic incantation.

I suspect it will be difficult to provide a workable solution for subsize displays without making the web app generally more layout-responsive, which might be EPIC. Likewise, I suspect that taking a mobile-first approach would be difficult to justify, given the aims of the app and the nature of its content.

However, I expect there are still small changes that could be made to at least improve the subsize experience.