### PR TITLE
Cache config

### DIFF
--- a/sampledata/datasets/Samples_and_Variants/datatables/variants/settings
+++ b/sampledata/datasets/Samples_and_Variants/datatables/variants/settings
@@ -71,8 +71,6 @@ properties:
   groupId: Info
   index: true                   # Instructs Panoptes to create a database index for this property. For large datasets, this massively speeds up queries based on this field
   showInBrowser: true           # If true, this property will be displayed in the genome browser
-  minVal: 0                     # Optional: For Value types, specifies the minimum value that can be reached.
-  maxVal: 1                     # Optional: For Value types, specifies the maximum value that can be reached.
   decimDigits: 2                # Optional: For Value types, specifies the number of decmimal digits that should be used to display the value
 
 - id: Value1
@@ -80,7 +78,9 @@ properties:
   dataType: Float
   description: The first numerical value
   showBar: true                   # Draws a bar in the background of the table, indicating the value. This requires MinVal & MaxVal to be defined
-  channelColor: rgb(0,80,200)    # Colour used to display this property
+  minVal: 0                       # Optional: For Value types, specifies the minimum value that can be reached.
+  maxVal: 1                       # Optional: For Value types, specifies the maximum value that can be reached.
+  channelColor: rgb(0,80,200)     # Colour used to display this property
   browserDefaultVisible: true
 
 - id: Value2
@@ -101,7 +101,6 @@ properties:
   description: An example categorical property
   dataType: Text
   showInBrowser: true
-  isCategorical: true               # This directive instructs Panoptes to treat the property as a categorical variable. For example, a combo box with the possible states is automatically shown in queries for this property
   categoryColors:                   # Specifies display colours for the categorical states of this property
     A: rgb(255,128,60)
     B: rgb(0,180,0)
@@ -116,6 +115,7 @@ properties:
 
 - id: NRAF_WAF
   description: Non-reference allele frequency in West Africa
+  isCategorical: false
 
 - id: NRAF_EAF
   description: Non-reference allele frequency in East Africa

--- a/server/responders/importer/ImportDataTable.py
+++ b/server/responders/importer/ImportDataTable.py
@@ -4,9 +4,18 @@
 
 import os
 import shutil
+
+from os.path import join
+
+import errno
+import simplejson
+
 from ProcessDatabase import ProcessDatabase
 from BaseImport import BaseImport
 from SettingsGraph import SettingsGraph
+from PanoptesConfig import PanoptesConfig
+from ImportSettings import valueTypes
+
 
 class ImportDataTable(BaseImport):
 
@@ -22,20 +31,39 @@ class ImportDataTable(BaseImport):
     def ImportDataTable(self, tableid):
         
         with self._logHeader('Importing datatable {0}'.format(tableid)):
-   
             tableSettings = self.getSettings(tableid)
-
             importer = ProcessDatabase(self._calculationObject, self._datasetId, self._importSettings)
-                       
             importer.importData(tableid, createSubsets = True)
-            
             importer.cleanUp()
-
             #Disabled till implemented in monet
             # filterBanker.createTableBasedSummaryValues(tableid)
-                
             self.importGraphs(tableid)
+            self.storeDataDerivedConfig(tableid)
 
+    def storeDataDerivedConfig(self, tableId):
+        with self._logHeader('Storing data derived config'):
+            config = PanoptesConfig(self._calculationObject)
+            baseFolder = join(config.getBaseDir(), 'config', self._datasetId, tableId)
+            config = {}
+            for propId in self._settingsLoader.getPropertyNames():
+                config[propId] = {}
+                prop = self._settingsLoader.getProperty(propId)
+                if 'isCategorical' not in prop and self._dao._execSqlQuery('select count(distinct "{0}") from "{1}"'.format(propId, tableId))[0][0] < 50:
+                    config[propId]['isCategorical'] = True
+                if (config[propId].get('isCategorical', False) or prop.get('isCategorical', False)) \
+                        and prop['dataType'] != 'Date':  #TODO Dates don't serialise nicely
+                    config[propId]['distinctValues'] = map(lambda a: a[0], self._dao._execSqlQuery('select distinct "{0}" from "{1}" order by "{0}"'.format(propId, tableId)))
+                if 'maxVal' not in prop and prop['dataType'] in valueTypes:
+                    config[propId]['maxVal'] = self._dao._execSqlQuery('select max("{0}") from "{1}"'.format(propId, tableId))[0][0]
+                if 'minVal' not in prop and prop['dataType'] in valueTypes:
+                    config[propId]['minVal'] = self._dao._execSqlQuery('select min("{0}") from "{1}"'.format(propId, tableId))[0][0]
+            try:
+                os.makedirs(baseFolder)
+            except OSError as exception:
+                if exception.errno != errno.EEXIST:
+                    raise
+            with open(join(baseFolder, 'dataConfig.json'), 'w') as f:
+                simplejson.dump(config, f)
 
     def importGraphs(self, tableid):
         folder = self._datatablesFolder

--- a/server/responders/importer/ImportSettings.py
+++ b/server/responders/importer/ImportSettings.py
@@ -12,11 +12,12 @@ from abc import ABCMeta
 import ruamel.yaml
 import portalocker
 
+valueTypes = ['Float', 'Double', 'Int8', 'Int16', 'Int32']
+
 class ImportSettings:
 
     __metaclass__ = ABCMeta
 
-    _valueTypes = ['Float', 'Double', 'Int8', 'Int16', 'Int32']
     _propertiesDefault = OrderedDict((
                             ('id', {
                                    'type': 'Text',
@@ -84,7 +85,7 @@ class ImportSettings:
                             ('isCategorical', {
                                    'type': 'Boolean',
                                    'required': False,
-                                   'description': 'Instructs Panoptes to treat the property as a categorical variable.\n  For example, a combo box with the possible states is automatically shown in queries for this property.\n  Categorical properties are automatically indexed'
+                                   'description': 'Set automatically for columns with <50 distinct entries, unless set. Instructs Panoptes to treat the property as a categorical variable.\n  For example, a combo box with the possible states is automatically shown in queries for this property.\n'
                                    }),
                             ('categoryColors', {
                                    'type': 'Block',
@@ -95,31 +96,31 @@ class ImportSettings:
                                    'type': 'Value',
                                    'required': False,
                                    'description': 'Sets the deafult column width in pixels.',
-                                   'siblingOptional': { 'name': 'dataType', 'value': _valueTypes}
+                                   'siblingOptional': { 'name': 'dataType', 'value': valueTypes}
                                    }),
                             ('showBar', {
                                    'type': 'Boolean',
                                    'required': False,
                                    'description': 'Draws a bar in the background of the table, indicating the value.\n  Requires *minVal* & *maxVal* to be defined.',
-                                   'siblingOptional': { 'name': 'dataType', 'value': _valueTypes}
+                                   'siblingOptional': { 'name': 'dataType', 'value': valueTypes}
                                    }),
                             ('minVal', {
                                    'type': 'Value',
                                    'required': False,
-                                   'description': 'For *Value* types, upper extent of scale',
-                                   'siblingOptional': { 'name': 'dataType', 'value': _valueTypes}
+                                   'description': 'Set automatically from data unless overridden. For *Value* types, upper extent of scale',
+                                   'siblingOptional': { 'name': 'dataType', 'value': valueTypes}
                                    }),
                             ('maxVal', {
                                    'type': 'Value',
                                    'required': False,
-                                   'description': 'For *Value* types, lower extent of scale',
-                                   'siblingOptional': { 'name': 'dataType', 'value': _valueTypes}
+                                   'description': 'Set automatically from data unless overridden. For *Value* types, lower extent of scale',
+                                   'siblingOptional': { 'name': 'dataType', 'value': valueTypes}
                                    }),
                             ('decimDigits', {
                                    'type': 'Value',
                                    'required': False,
                                    'description': 'For *Value* types, specifies the number of decimal digits used to display the value',
-                                   'siblingOptional': { 'name': 'dataType', 'value': _valueTypes}
+                                   'siblingOptional': { 'name': 'dataType', 'value': valueTypes}
                                    }),
                             ('index', {
                                    'type': 'Boolean',

--- a/server/responders/importer/configReadWrite.py
+++ b/server/responders/importer/configReadWrite.py
@@ -1,5 +1,7 @@
 from os import path, listdir
 from os.path import join
+
+from os.path import exists
 from simplejson import load, loads, dumps
 from PanoptesConfig import PanoptesConfig
 from SettingsDataset import SettingsDataset
@@ -13,6 +15,7 @@ config = PanoptesConfig(None)
 sourceDir = join(config.getSourceDataDir(), 'datasets')
 baseDir = config.getBaseDir()
 
+
 def readSetOfSettings(dirPath, loader, wanted_names=None):
     if not path.isdir(dirPath):
         return {}
@@ -20,24 +23,40 @@ def readSetOfSettings(dirPath, loader, wanted_names=None):
                  for name in listdir(dirPath)
                   if path.isdir(join(dirPath, name)) and (not wanted_names or name in wanted_names)}
 
+
 def readJSONConfig(datasetId):
-    datasetFolder = join(sourceDir, datasetId)
-    baseFolder = join(baseDir, 'config', datasetId)
-    if not path.isdir(datasetFolder):
+    dataset_folder = join(sourceDir, datasetId)
+    base_folder = join(baseDir, 'config', datasetId)
+    if not path.isdir(dataset_folder):
         raise Exception('Error: ' + datasetId + ' is not a known dataset in the source directory')
-    settingsFile = join(datasetFolder, 'settings')
-    settings = loads(SettingsDataset(settingsFile, validate=True).serialize())
+    settings_file = join(dataset_folder, 'settings')
+    settings = loads(SettingsDataset(settings_file, validate=True).serialize())
     try:
-        with open(join(baseFolder, 'chromosomes.json'), 'r') as f:
+        with open(join(base_folder, 'chromosomes.json'), 'r') as f:
             chromosomes = load(f)
     except IOError:
         print('Cached chrom config not found - scanning')
-        chromosomes = readChromLengths(join(datasetFolder, 'refgenome', 'refsequence.fa'))
+        chromosomes = readChromLengths(join(dataset_folder, 'refgenome', 'refsequence.fa'))
 
-    tables = readSetOfSettings(join(datasetFolder, 'datatables'), SettingsDataTable, settings.get('DataTables'))
-    twoDTables = readSetOfSettings(join(datasetFolder, '2D_datatables'), Settings2Dtable, settings.get('2D_DataTables'))
-    genome = loads(SettingsRefGenome(join(datasetFolder, 'refgenome', 'settings'), validate=True).serialize())
-    mapLayers = readSetOfSettings(join(datasetFolder, 'maps'), SettingsMapLayer)
+    tables = readSetOfSettings(join(dataset_folder, 'datatables'), SettingsDataTable, settings.get('DataTables'))
+    try:
+        for tableId, table_config in tables.items():
+            config_file = join(base_folder, tableId, 'dataConfig.json')
+            print(config_file)
+            if exists(config_file):
+                with open(config_file, 'r') as f:
+                    data_config = load(f)
+                    for prop in table_config['properties']:
+                        if prop['id'] in data_config:
+                            for key, value in data_config[prop['id']].items():
+                                if key not in prop:
+                                    prop[key] = value
+
+    except IOError:
+        print('Cached data derived config not found - skipping')
+    twoDTables = readSetOfSettings(join(dataset_folder, '2D_datatables'), Settings2Dtable, settings.get('2D_DataTables'))
+    genome = loads(SettingsRefGenome(join(dataset_folder, 'refgenome', 'settings'), validate=True).serialize())
+    mapLayers = readSetOfSettings(join(dataset_folder, 'maps'), SettingsMapLayer)
     return {
         'settings': settings,
         'chromosomes': chromosomes,
@@ -54,16 +73,16 @@ class ReadOnlyErrorWriter:
         raise Exception("The config at:"+'.'.join([self.name]+updatePath)+" is read-only")
 
 def writeJSONConfig(datasetId, action, path, newConfig):
-    datasetFolder = join(sourceDir, datasetId)
-    settingsFile = join(datasetFolder, 'settings')
+    dataset_folder = join(sourceDir, datasetId)
+    settings_file = join(dataset_folder, 'settings')
     #We have a path in the combined JSON object - we now follow the path until we hit a subset confined to one YAML handler
     writers = {
-        'settings': lambda path: (path, SettingsDataset(settingsFile, validate=True)),
+        'settings': lambda path: (path, SettingsDataset(settings_file, validate=True)),
         'chromosomes': lambda path: (path, ReadOnlyErrorWriter('chromosomes')),
         'genome': lambda path: (path, ReadOnlyErrorWriter('genome')), #For now as this will likely get a refactor
         'mapLayers': lambda path: (path, ReadOnlyErrorWriter('mapLayers')),  # For now as this will likely get a refactor
-        'tablesById': lambda path: (path[1:], SettingsDataTable(join(datasetFolder, 'datatables', path[0], 'settings'), validate=True)),
-        'twoDTablesById': lambda path: (path[1:], SettingsDataTable(join(datasetFolder, '2D_datatables', path[0], 'settings'), validate=True)),
+        'tablesById': lambda path: (path[1:], SettingsDataTable(join(dataset_folder, 'datatables', path[0], 'settings'), validate=True)),
+        'twoDTablesById': lambda path: (path[1:], SettingsDataTable(join(dataset_folder, '2D_datatables', path[0], 'settings'), validate=True)),
     }
     path = path.split('.')
     (path, writer) = writers[path[0]](path[1:])

--- a/server/responders/importer/readChromLengths.py
+++ b/server/responders/importer/readChromLengths.py
@@ -1,0 +1,4 @@
+from Bio import SeqIO
+def readChromLengths(fasta):
+    with open(fasta, 'r') as fastaFile:
+        return {fasta.id: len(fasta.seq) for fasta in SeqIO.parse(fastaFile, 'fasta')}

--- a/webapp/src/js/components/containers/FindGene.js
+++ b/webapp/src/js/components/containers/FindGene.js
@@ -74,7 +74,7 @@ let FindGene = React.createClass({
 
     if ((setChromosome === null || setChromosome === undefined)  && defaultChromosome !== null) {
 
-      let defaultChromosomeLength = parseInt(this.config.chromosomes[defaultChromosome].len);
+      let defaultChromosomeLength = parseInt(this.config.chromosomes[defaultChromosome]);
 
       setChromosomeLength = defaultChromosomeLength;
       setChromosome = defaultChromosome;

--- a/webapp/src/js/components/containers/FindGeneByRegion.js
+++ b/webapp/src/js/components/containers/FindGeneByRegion.js
@@ -58,15 +58,15 @@ let FindGeneByRegion = React.createClass({
   },
 
   componentWillMount() {
-    this.props.setProps({'endPosition': parseInt(this.config.chromosomes[this.props.chromosome].len)});
+    this.props.setProps({'endPosition': parseInt(this.config.chromosomes[this.props.chromosome])});
   },
 
   handleChromChange(event) {
     this.props.setProps({
       'chromosome': event.target.value,
-      'chromosomeLength': parseInt(this.config.chromosomes[event.target.value].len),
+      'chromosomeLength': parseInt(this.config.chromosomes[event.target.value]),
       'startPosition': 0,
-      'endPosition': parseInt(this.config.chromosomes[event.target.value].len)
+      'endPosition': parseInt(this.config.chromosomes[event.target.value])
     });
   },
 

--- a/webapp/src/js/components/panoptes/PropertyLegend.js
+++ b/webapp/src/js/components/panoptes/PropertyLegend.js
@@ -36,7 +36,7 @@ let PropertyLegend = React.createClass({
         <LegendElement key="false" name="False" colour={colourFunc(false)} />
       ];
     } else if (propConfig.isCategorical || propConfig.isText) {
-      elements = _map(propConfig.propCategories || knownValues || [], (value) => (
+      elements = _map(propConfig.distinctValues || knownValues || [], (value) => (
         <LegendElement key={value} name={value} colour={colourFunc(value)} />));
     } else {
       const colour = scaleColour([0, 1]);

--- a/webapp/src/js/components/panoptes/QueryEditor.js
+++ b/webapp/src/js/components/panoptes/QueryEditor.js
@@ -235,8 +235,8 @@ let Criterion = React.createClass({
 
     // TODO: This logic is essentially replicated from render(). Possible to abstract?
     if (currentOperator.fieldType === 'value') {
-      if (property.propCategories) {
-        component.CompValue = property.propCategories[0];
+      if (property.distinctValues) {
+        component.CompValue = property.distinctValues[0];
       } else if (property.isBoolean) {
         component.CompValue = true;
       }
@@ -381,13 +381,13 @@ let Criterion = React.createClass({
     if (!currentOperator)
       throw Error('SQL criterion operator not valid');
     if (currentOperator.fieldType === 'value') {
-      if (property.propCategories) {
+      if (property.distinctValues) {
         fields = (
           <div className="fields">
             <select className="field" ref="value"
                     value={component.CompValue}
                     onChange={this.handleValueChange}>
-              {property.propCategories.map((cat) =>
+              {property.distinctValues.map((cat) =>
                 <option key={cat}
                         value={cat}>
                   {cat}

--- a/webapp/src/js/components/panoptes/genome/Controls.js
+++ b/webapp/src/js/components/panoptes/genome/Controls.js
@@ -7,7 +7,7 @@ import PureRenderMixin from 'mixins/PureRenderMixin';
 import ConfigMixin from 'mixins/ConfigMixin';
 import FluxMixin from 'mixins/FluxMixin';
 
-const FALLBACK_MAXIMUM = 1000000000;
+const FALLBACK_MAXIMUM = 214700000;
 
 let Controls = React.createClass({
   mixins: [
@@ -59,7 +59,7 @@ let Controls = React.createClass({
       _isFinite(mid) &&
       _isFinite(width) &&
       mid >= 0 &&
-      mid <= (this.config.chromosomes[this.props.chromosome].len || FALLBACK_MAXIMUM) &&
+      mid <= (this.config.chromosomes[this.props.chromosome] || FALLBACK_MAXIMUM) &&
       width > this.props.minWidth
     ) {
       this.props.setProps({
@@ -90,7 +90,7 @@ let Controls = React.createClass({
   render() {
     let {chromosome, minWidth} = this.props;
     let {midpoint, width, regionText, regionValid} = this.state;
-    let max = this.config.chromosomes[chromosome].len || FALLBACK_MAXIMUM;
+    let max = this.config.chromosomes[chromosome] || FALLBACK_MAXIMUM;
     return (
       <span className="controls">
         <span> Chromosome: </span>

--- a/webapp/src/js/components/panoptes/genome/GenomeBrowser.js
+++ b/webapp/src/js/components/panoptes/genome/GenomeBrowser.js
@@ -90,7 +90,7 @@ let GenomeBrowser = React.createClass({
     let {chromosome} = this.props;
     chromosome = chromosome || this.defaultChrom;
     let min = 0;
-    let max = this.config.chromosomes[chromosome].len || FALLBACK_MAXIMUM;
+    let max = this.config.chromosomes[chromosome] || FALLBACK_MAXIMUM;
     let width = end - start;
     if (start <= min && end >= max) {
       start = min;

--- a/webapp/src/js/panoptes/Formatter.js
+++ b/webapp/src/js/panoptes/Formatter.js
@@ -34,5 +34,5 @@ module.exports = function(property, value) {
         return value.toFixed(property.decimDigits).toString();
     }
   }
-  return value === undefined ? '' : value.toString();
+  return (value === undefined || value === null) ? '' : value.toString();
 };

--- a/webapp/src/js/util/Colours.js
+++ b/webapp/src/js/util/Colours.js
@@ -59,8 +59,8 @@ export function propertyColour(propConfig, min = null, max = null) {
   if (propConfig.isCategorical) {
     const colourFunc = categoryColours(`${propConfig.tableId}_${propConfig.id}`);
     //Run thorugh the possibilites so they are enumerated in sort order, not appearance order.
-    if (propConfig.propCategories) {
-      propConfig.propCategories.forEach(colourFunc);
+    if (propConfig.distinctValues) {
+      propConfig.distinctValues.forEach(colourFunc);
     }
     return colourFunc;
   }


### PR DESCRIPTION
On import calculate chrom lengths, and for columns max, min, isCategorical and distinctValues store and then read with the normal config on page load. Note that max, min, isCategorical and distinctValues can be overridden in normal config.

Fixes #563, #532, #505 but exposes #540