### PR TITLE
Add system of HTML pages

### DIFF
--- a/documentation/importdata/sourcefilesstructure/docs.rst
+++ b/documentation/importdata/sourcefilesstructure/docs.rst
@@ -5,11 +5,12 @@ Documentation source files
 A :ref:`dataset source folder<def-source-dataset>` may optionally contain a subfolder ``doc``,
 containing html files that can be displayed in Panoptes' internal documentation viewer.
 
-These files should follow proper XML formatting, and contain a ``<body>`` element.
-The html may contain hyperlinks to other documentation files in the same source directory, or to external links.
+These files should follow proper HTML formatting, similar to the contents of a normal <body> tag.
+
+A <title> tag can be used to specify the name given to the tab or popup where the content appears.
 
 These documents may be referred to in other components of the source data, such as descriptions of the dataset or data tables.
-Referring happens through a hyperlink with the structure ``<a class="doclink" href="[docid]">hyperlink display name</a>``,
-with [docid] the file name of the document file *without the .html extension*.
+Referring happens through a hyperlink with the structure ``<DocLink href="[filename]">hyperlink display name</DocLink>``.
 
-On the deployment, this will render as a hyperlink that leads to an in-app popup showing the documentation in the source file.
+
+On the deployment, this will render as a hyperlink that leads to an in-app tab showing the documentation in the source file.

--- a/sampledata/datasets/Samples_and_Variants/datatables/contributors/settings
+++ b/sampledata/datasets/Samples_and_Variants/datatables/contributors/settings
@@ -67,7 +67,7 @@ dataItemViews:
       <ItemMap table='samplingsites' highlight='Contributor_ID:{{ID}}' />
     </div>
     <h4>
-      More information on the nature of contribution <a class="doclink" href="samples">here</a>
+      More information on the nature of contribution <DocLink href="samples.html">here</DocLink>
     </h4>
 
 

--- a/sampledata/datasets/Samples_and_Variants/datatables/samples/settings
+++ b/sampledata/datasets/Samples_and_Variants/datatables/samples/settings
@@ -3,8 +3,8 @@
 nameSingle: sample    # Display name referring to a table item (single, no capital)
 namePlural: samples    # Display name referring to a table item (plural, no capital)
 
-description: 'A table containing a number of samples. <a class="doclink" href="samples">More
-  information...</a>.
+description: 'A table containing a number of samples. <DocLink href="samples.html">More
+  information...</DocLink>.
 
   '
 icon: fa-flask

--- a/sampledata/datasets/Samples_and_Variants/doc/genomebrowser.html
+++ b/sampledata/datasets/Samples_and_Variants/doc/genomebrowser.html
@@ -1,10 +1,4 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title></title>
-</head>
-<body>
-
+<title>Genome Browser</title>
 <h1>
     Genome browser info
 </h1>
@@ -14,7 +8,4 @@
     This page describes what a user can do in the genome browser view.
 </p>
 
-See also <a href="intro.html">Intro documentation</a>.
-
-</body>
-</html>
+See also <DocLink href="intro.html">Intro documentation</DocLink>.

--- a/sampledata/datasets/Samples_and_Variants/doc/intro.html
+++ b/sampledata/datasets/Samples_and_Variants/doc/intro.html
@@ -1,11 +1,4 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title></title>
-</head>
-<body>
-
-
+<title>Intro text</title>
 <h1>Introduction</h1>
 
 
@@ -18,15 +11,15 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec sit amet fermentu
 <h2>Related topics</h2>
 <ul>
     <li>
-        <a href="introsub1.html">Subcomponent 1</a>
+        <DocLink href="introsub1.html">Subcomponent 1</DocLink>
     </li>
     <li>
-        <a href="introsub2.html">Subcomponent 2</a>
+        <DocLink href="introsub2.html">Subcomponent 2</DocLink>
     </li>
     <li>
         <a href="http://panoptes.readthedocs.org/en/latest/">External link: panoptes.readthedocs.org</a>
     </li>
 </ul>
-
-</body>
-</html>
+<div style="position:relative;width:400px;height:400px">
+  <TablePlotWidget plotType="scatter" table="variants" horizontal="Value1" vertical="Value2" />
+</div>

--- a/sampledata/datasets/Samples_and_Variants/doc/introsub1.html
+++ b/sampledata/datasets/Samples_and_Variants/doc/introsub1.html
@@ -1,10 +1,4 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title></title>
-</head>
-<body>
-
+<title>Extra Info 1</title>
 <h1>First subcomponent of intro documentation</h1>
 
 <p>
@@ -14,12 +8,9 @@ Integer laoreet semper vestibulum. In quis dolor non sapien sollicitudin maximus
 See also:
 <ul>
     <li>
-        <a href="introsub2.html">Subcomponent 2</a>
+        <DocLink href="introsub2.html">Subcomponent 2</DocLink>
     </li>
     <li>
-        <a href="intro.html">Intro documentation</a>
+        <DocLink href="intro.html">Intro documentation</DocLink>
     </li>
 </ul>
-
-</body>
-</html>

--- a/sampledata/datasets/Samples_and_Variants/doc/introsub2.html
+++ b/sampledata/datasets/Samples_and_Variants/doc/introsub2.html
@@ -1,10 +1,4 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title></title>
-</head>
-<body>
-
+<title>Extra Info 2</title>
 <h1>Second subcomponent of intro documentation</h1>
 
 Vestibulum congue, neque et porttitor ultrices, enim quam interdum nunc, ac sollicitudin neque magna a ex. In non dignissim lorem. Vestibulum vitae est fermentum, pellentesque leo at, varius massa. Aliquam dictum venenatis elit, ut luctus justo. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Ut mattis et tortor in laoreet. Ut dictum elementum dolor vel placerat. Nulla consequat nunc ut metus volutpat, accumsan euismod dolor rutrum. Sed iaculis placerat mollis. Aliquam vitae dolor ex. In ut malesuada ex. Suspendisse potenti. Sed lacinia posuere venenatis. Nunc porta vestibulum risus ac congue.
@@ -12,12 +6,9 @@ Vestibulum congue, neque et porttitor ultrices, enim quam interdum nunc, ac soll
 See also:
 <ul>
     <li>
-        <a href="introsub1.html">Subcomponent 1</a>
+        <DocLink href="introsub1.html">Subcomponent 1</DocLink>
     </li>
     <li>
-        <a href="intro.html">Intro documentation</a>
+        <DocLink href="intro.html">Intro documentation</DocLink>
     </li>
 </ul>
-
-</body>
-</html>

--- a/sampledata/datasets/Samples_and_Variants/doc/samples.html
+++ b/sampledata/datasets/Samples_and_Variants/doc/samples.html
@@ -1,10 +1,4 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title></title>
-</head>
-<body>
-
+<title>Samples Info</title>
 <h1>
     Samples info
 </h1>
@@ -14,7 +8,4 @@
 Ut tellus lacus, aliquet sit amet magna nec, venenatis ultricies magna. Sed semper condimentum libero, fermentum scelerisque eros interdum vel. Donec imperdiet odio sapien, ut sodales sapien iaculis dignissim. Nulla maximus tempus lectus venenatis euismod. Aenean pellentesque mollis risus, sed laoreet lectus tincidunt imperdiet. Morbi elementum bibendum eros, in sodales neque tristique eget. Nullam mollis convallis enim eu venenatis. In non vehicula lectus.
 </p>
 
-See also <a href="intro.html">Intro documentation</a>.
-
-</body>
-</html>
+See also <DocLink href="intro.html">Intro documentation</DocLink>.

--- a/sampledata/datasets/Samples_and_Variants/settings
+++ b/sampledata/datasets/Samples_and_Variants/settings
@@ -10,7 +10,7 @@ description: |
   A second line, html formatted
   </div>
   An <a href="http://panoptes.readthedocs.org/en/latest//"
-  target="_blank">external hyperlink</a> and a <a class="doclink" href="intro">link</a>
+  target="_blank">external hyperlink</a> and a <DocLink href="intro.html">link</DocLink>
   to documentation part of this deployment.
   <p>Some buttons that open popups:</p>
   <PopupButton label="Plot of Variants" icon="area-chart">
@@ -25,6 +25,10 @@ description: |
   <PopupButton>
     <div>Some <b>config specified</b> content</div>
   </PopupButton>
+  <p>A table, with styled headers</p>
+  <div style="position:relative;height:150px">
+      <PivotTableView table="variants" columnProperty="Extra_1" rowProperty="HighQuality" />
+  </div>
   <p>A tree of samples</p>
   <div style="position:relative;width:300px;height:300px">
     <TreeContainer table="samples" tree="tree2" />

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -52,9 +52,6 @@ fi
 if ! [ -w $BASEDIR/temp ]; then
     echo -e "${red}  WARNING ${BASEDIR}/temp is not writable by this user - it needs to be for the user that panoptes is run under"
 fi
-if ! [ -w $BASEDIR/SummaryTracks ]; then
-    echo -e "${red}  WARNING ${BASEDIR}/SummaryTracks is not writable by this user - it needs to be for the user that panoptes is run under"
-fi
 if ! [ -w $BASEDIR/Uploads ]; then
     echo -e "${red}  WARNING ${BASEDIR}/Uploads is not writable by this user - it needs to be for the user that panoptes is run under"
 fi

--- a/server/responders/importer/ImportFiles.py
+++ b/server/responders/importer/ImportFiles.py
@@ -26,9 +26,17 @@ def ImportDocs(calculationObject, datasetFolder, datasetId):
         try:
             shutil.rmtree(destDocFolder)
         except OSError:
+            try:
+                #Symbolic links error for rmtree
+                os.remove(destDocFolder)
+            except:
+                pass
             #Don't fail if exists
             pass
-        shutil.copytree(sourceDocFolder, destDocFolder)
+        try:
+            os.symlink(sourceDocFolder, destDocFolder)
+        except:
+            shutil.copytree(sourceDocFolder, destDocFolder)
 
 
 #TODO: Identical to ImportDocs

--- a/webapp/gulp/tasks/server.js
+++ b/webapp/gulp/tasks/server.js
@@ -20,6 +20,10 @@ var devConfig = {
       '/panoptes/api': {
         target: 'http://localhost:8000/',
         secure: false
+      },
+      '/panoptes/Docs': {
+        target: 'http://localhost:8000/',
+        secure: false
       }
     }
   };

--- a/webapp/src/index.html
+++ b/webapp/src/index.html
@@ -71,11 +71,14 @@
       -webkit-box-align: center;
           -ms-flex-align: center;
               align-items: center;
+      -webkit-box-orient: vertical;
+      -webkit-box-direction: normal;
+      flex-direction: column;
       height: 100%;
       width: 100%;
       background-color: rgb(255, 255, 255);
     }
-    .non-js-spinner div {
+    .non-js-spinner .logo {
       height: 50%;
       width: 50%;
       opacity: 0.5;
@@ -86,6 +89,15 @@
       background-position: center;
       background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB2aWV3Qm94PSIwIDAgMTA2MCAxMTEwIj4KPGNpcmNsZSBjeD0iNTMwIiBjeT0iNTU1IiByPSIzODUiIGZpbGw9IiM3ODc4NzgiLz4KPGNpcmNsZSBjeD0iNTMwIiBjeT0iNTU1IiByPSIzMjUiIGZpbGw9IndoaXRlIi8+CjxjaXJjbGUgY3g9Ijc0MCIgY3k9IjgyNSIgcj0iMTE1IiBmaWxsPSIjNzg3ODc4Ii8+CjxjaXJjbGUgY3g9IjY3NSIgY3k9IjE5MSIgcj0iMTkwIiBmaWxsPSIjNzg3ODc4Ii8+CjxjaXJjbGUgY3g9IjY3NSIgY3k9IjE5MSIgcj0iMTUwIiBmaWxsPSJsaWdodGdyZXkiLz4KPGNpcmNsZSBjeD0iMTcwIiBjeT0iNTU1IiByPSIxNzIiIGZpbGw9IiM3ODc4NzgiLz4KPGNpcmNsZSBjeD0iMTcwIiBjeT0iNTU1IiByPSIxNDUiIGZpbGw9IiNGRkZGRkYiLz4KPGNpcmNsZSBjeD0iMTcwIiBjeT0iNTU1IiByPSIxMTUiIGZpbGw9ImxpZ2h0Z3JleSIvPgo8Y2lyY2xlIGN4PSI3NDAiIGN5PSI4MjUiIHI9IjkwIiBmaWxsPSJsaWdodGdyZXkiLz4KPGNpcmNsZSBjeD0iNTMwIiBjeT0iNTU1IiByPSIyOTAiIGZpbGw9IiM3ODc4NzgiLz4KPGNpcmNsZSBjeD0iNTMwIiBjeT0iNTU1IiByPSI4MCIgZmlsbD0id2hpdGUiLz4KPGNpcmNsZSBjeD0iMTcwIiBjeT0iNTU1IiByPSI2MCIgZmlsbD0iIzc4Nzg3OCIvPgo8Y2lyY2xlIGN4PSI2NzUiIGN5PSIxOTEiIHI9Ijc3IiBmaWxsPSIjNzg3ODc4Ii8+CjxjaXJjbGUgY3g9Ijc0MCIgY3k9IjgyNSIgcj0iNDUiIGZpbGw9IiM3ODc4NzgiLz4KPC9zdmc+Cg==");
     }
+    .error-text {
+      font-style: italic;
+      padding-top: 15px;
+    }
+    body {
+      font-family: 'Roboto', sans-serif;
+      color: rgb(36, 36, 36);
+      font-size: 14px;
+    }
   </style>
 </head>
 <body id="body">
@@ -95,9 +107,9 @@
   document.getElementById('body').removeChild(document.getElementById('JSwarning'))
 </script>
 <div id="main" class="main">
-  <div
-    class="non-js-spinner">
-    <div />
+  <div class="non-js-spinner">
+    <div class="logo"></div>
+    <div class="error-text">Loading panoptes...</div>
   </div>
 </div>
 </body>

--- a/webapp/src/js/components/panoptes/DataTableView.js
+++ b/webapp/src/js/components/panoptes/DataTableView.js
@@ -213,7 +213,7 @@ let DataTableView = React.createClass({
     if (columns.length > 0)
       return (
         <DetectResize onResize={this.handleResize}>
-          <div className={classNames('datatable', className)}>
+          <div className={classNames('load-container', className)}>
             <Table
               rowHeight={ROW_HEIGHT}
               //rowGetter={(index) => rows[index]}
@@ -307,7 +307,7 @@ let DataTableView = React.createClass({
       );
     else
       return (
-        <div className={classNames('datatable', className)}>
+        <div className={classNames('load-container', className)}>
           <Loading status="custom">No columns selected</Loading>
         </div>
       );

--- a/webapp/src/js/components/panoptes/DocLink.js
+++ b/webapp/src/js/components/panoptes/DocLink.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import DocPage from 'panoptes/DocPage';
+
+// Mixins
+import PureRenderMixin from 'mixins/PureRenderMixin';
+import FluxMixin from 'mixins/FluxMixin';
+
+let DocLink = React.createClass({
+
+  mixins: [
+    PureRenderMixin,
+    FluxMixin
+  ],
+
+  propTypes: {
+    href: React.PropTypes.string,
+    replaceParent: React.PropTypes.func
+  },
+
+  handleClick(e) {
+    let {href, replaceParent} = this.props;
+    const middleClick =  e.button == 1 || e.metaKey || e.ctrlKey;
+    e.stopPropagation();
+    if (middleClick) {
+      this.getFlux().actions.session.tabOpen(<DocPage path={href} />, false);
+    } else {
+      if (replaceParent) {
+        replaceParent(<DocPage path={href} />);
+      } else {
+        this.getFlux().actions.session.tabOpen(<DocPage path={href} />, true);
+      }
+    }
+  },
+
+  render() {
+    return (
+      <a
+        onClick={(e) => this.handleClick(e)}
+      >
+        {this.props.children}
+      </a>
+    );
+  }
+
+});
+
+export default DocLink;

--- a/webapp/src/js/components/panoptes/DocPage.js
+++ b/webapp/src/js/components/panoptes/DocPage.js
@@ -1,0 +1,116 @@
+import React from 'react';
+import API from 'panoptes/API';
+import LRUCache from 'util/LRUCache';
+import ErrorReport from 'panoptes/ErrorReporter';
+import HTMLWithComponents from 'panoptes/HTMLWithComponents';
+import htmlparser from 'htmlparser2';
+import Loading from 'ui/Loading';
+
+// Mixins
+import ConfigMixin from 'mixins/ConfigMixin';
+import PureRenderMixin from 'mixins/PureRenderMixin';
+import FluxMixin from 'mixins/FluxMixin';
+import DataFetcherMixin from 'mixins/DataFetcherMixin';
+
+let DocPage = React.createClass({
+  mixins: [
+    ConfigMixin,
+    PureRenderMixin,
+    FluxMixin,
+    DataFetcherMixin('path')
+  ],
+
+  getInitialState() {
+    return {
+      content: '',
+      loadStatus: 'loading'
+    }
+  },
+
+  propTypes: {
+    path: React.PropTypes.string,
+    replaceSelf: React.PropTypes.func,
+    updateTitleIcon: React.PropTypes.func
+  },
+
+  componentWillMount() {
+    this.titleFromHTML = 'Loading...'
+  },
+
+  fetchData(props, requestContext) {
+    const {path} = props;
+    if (path !== this.props.path) {
+      this.titleFromHTML = 'Loading...';
+      this.setState(this.getInitialState());
+    }
+    const {dataset} = this.config;
+    requestContext.request((componentCancellation) =>
+      LRUCache.get(
+        'staticContent' + path,
+        (cacheCancellation) =>
+          API.staticContent({cancellation: cacheCancellation, url: `/panoptes/Docs/${dataset}/${path}`}),
+        componentCancellation
+      )
+    )
+      .catch(API.filterAborted)
+      .catch(LRUCache.filterCancelled)
+      .then((content) => this.setState({loadStatus: 'loaded', content}))
+      .catch((error) => {
+        this.setState({loadStatus: 'error', content: ''});
+        ErrorReport(this.getFlux(), error.message, () => this.fetchData(this.props, requestContext));
+        throw error;
+      })
+      .done();
+  },
+
+  componentWillUpdate(nextProps, nextState) {
+    if (this.state.content !== nextState.content && nextState.content != '') {
+      let inTitle = false;
+      let title = 'Untitled';
+      const parser = new htmlparser.Parser({
+        onopentag: function (tagname, attribs) {
+          if (tagname === "title") {
+            inTitle = true;
+          }
+        },
+        ontext: function(text){
+            if (inTitle) {
+              title = text;
+            }
+        },
+        onclosetag: function(tagname){
+            if(tagname === "title"){
+              inTitle = false;
+            }
+        }
+      }, {decodeEntities: true});
+      parser.write(nextState.content);
+      parser.end();
+      if (title !== this.titleFromHTML) {
+        this.titleFromHTML = title;
+        if (nextProps.updateTitleIcon) {
+          nextProps.updateTitleIcon()
+        }
+      }
+    }
+  },
+
+  title() {
+    return this.titleFromHTML;
+  },
+  icon() {
+    return 'file-text-o';
+  },
+
+  render() {
+    const {content, loadStatus} = this.state;
+    const {replaceSelf} = this.props;
+    return <div className="load-container">
+      <HTMLWithComponents replaceSelf={replaceSelf}>{content}</HTMLWithComponents>;
+      <Loading status={loadStatus}/>
+    </div>;
+  }
+
+});
+
+export default DocPage;

--- a/webapp/src/js/components/panoptes/HTMLWithComponents.js
+++ b/webapp/src/js/components/panoptes/HTMLWithComponents.js
@@ -3,6 +3,7 @@ import HtmlToReact from 'html-to-react';
 import ComponentRegistry from 'util/ComponentRegistry';
 import _forEach from 'lodash/forEach';
 import _camelCase from 'lodash/camelCase';
+import DocLink from 'panoptes/DocLink';
 
 function createStyleJsonFromString(styleString) {
   if (!styleString) {
@@ -25,7 +26,8 @@ let HTMLWithComponents = React.createClass({
 
   propTypes: {
     className: React.PropTypes.string,
-    children: React.PropTypes.string
+    children: React.PropTypes.string,
+    replaceSelf: React.PropTypes.func
   },
 
   componentWillMount() {
@@ -45,7 +47,7 @@ let HTMLWithComponents = React.createClass({
           _forEach(node.attribs, (value, key) => {
             switch (key || '') {
             case 'style':
-              elementProps.style = createStyleJsonFromString(node.attribs.style);
+              elementProps.style = createStyleJsonFromString(value);
               break;
             case 'class':
               elementProps.className = value;
@@ -76,6 +78,9 @@ let HTMLWithComponents = React.createClass({
               break;
             }
           });
+          if (type === DocLink) {
+            elementProps.replaceParent = this.props.replaceSelf;
+          }
           return React.createElement(type, {children, ...elementProps});
         }
       },
@@ -94,8 +99,8 @@ let HTMLWithComponents = React.createClass({
   },
 
   render() {
-    return this.htmlToReact(`<div class="${this.props.className}">${this.props.children}</div>`);
+    return this.htmlToReact(`<div class="${this.props.className ? this.props.className : ''}">${this.props.children}</div>`);
   }
 });
 
-module.exports = HTMLWithComponents;
+export default HTMLWithComponents;

--- a/webapp/src/js/components/panoptes/PivotTableView.js
+++ b/webapp/src/js/components/panoptes/PivotTableView.js
@@ -154,7 +154,7 @@ let PivotTableView = React.createClass({
     }
     return (
       <DetectResize onResize={this.handleResize}>
-        <div className={classNames('datatable', className)}>
+        <div className={classNames('load-container', className)}>
           <Table
             rowHeight={ROW_HEIGHT}
             rowsCount={uniqueRows.length}

--- a/webapp/src/js/components/ui/Loading.js
+++ b/webapp/src/js/components/ui/Loading.js
@@ -17,6 +17,7 @@ let Loading = React.createClass({
       return (
         <div className="loading-container show">
           <div className="spinner load-icon" />
+          {this.props.children}
         </div>
       );
 
@@ -24,14 +25,15 @@ let Loading = React.createClass({
       return (
         <div className="loading-container show hide-content">
           <div className="spinner load-icon" />
-
+          <div className="error-text">{this.props.children}</div>
         </div>
       );
 
     if (status == 'error')
       return (
         <div className="loading-container show">
-          <div className="error load-icon"/><div className="error-text">{this.props.children}</div>
+          <div className="error load-icon"/>
+          <div className="error-text">{this.props.children}</div>
         </div>
       );
 

--- a/webapp/src/js/components/ui/TabPane.js
+++ b/webapp/src/js/components/ui/TabPane.js
@@ -9,7 +9,8 @@ let TabPane = React.createClass({
     title: React.PropTypes.string,
     active: React.PropTypes.bool, //Usually set by TabbedArea
     children: React.PropTypes.element,
-    className: React.PropTypes.string
+    className: React.PropTypes.string,
+    updateTitleIcon: React.PropTypes.func
   },
 
   icon() {
@@ -45,7 +46,10 @@ let TabPane = React.createClass({
 
     return (
       <div {...divProps} className={classNames(this.props.className, classes)}>
-        {React.cloneElement(this.props.children, {ref: (node) => this.child = node})}
+        {React.cloneElement(this.props.children, {
+          updateTitleIcon: this.props.updateTitleIcon,
+          ref: (node) => this.child = node
+        })}
       </div>
     );
   }

--- a/webapp/src/js/components/ui/TabbedArea.js
+++ b/webapp/src/js/components/ui/TabbedArea.js
@@ -142,7 +142,8 @@ let TabbedArea = React.createClass({
       {
         active: (tab.props.compId === this.props.activeTab),
         key: tab.props.compId,
-        ref: tab.props.compId
+        ref: tab.props.compId,
+        updateTitleIcon: () => this.forceUpdate()
       });
   },
 

--- a/webapp/src/js/index.js
+++ b/webapp/src/js/index.js
@@ -40,8 +40,6 @@ import 'normalize.css';
 //https://github.com/zilverline/react-tap-event-plugin
 injectTapEventPlugin();
 
-//Throw up a loader till we are ready
-ReactDOM.render(<div><Loading status="loading-hide"/></div>, document.getElementById('main'));
 
 const HASH_REGEX = /\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$/;
 
@@ -101,6 +99,7 @@ Promise.prototype.done = function (onFulfilled, onRejected) {
 };
 const {dataset, state} = getAppState(window.location);
 if (dataset) {  //dataset being "panoptes" means that root URL is being hit
+  ReactDOM.render(<div><Loading status="loading-hide">Loading {dataset}...</Loading></div>, document.getElementById('main'));
   Promise.all([InitialConfig(dataset), state]) //eslint-disable-line no-undef
     .then(([config, appState]) => {
       let stores = {

--- a/webapp/src/js/panoptes/API.js
+++ b/webapp/src/js/panoptes/API.js
@@ -562,6 +562,11 @@ function query(options) {
     // });
 }
 
+function staticContent(options) {
+  assertRequired(options, ['url']);
+  return request(options).then((resp) => resp.responseText);
+}
+
 const nullValues = {
   i1: -128,
   i2: -32768,
@@ -592,5 +597,6 @@ module.exports = {
   summaryData,
   storeData,
   treeData,
-  twoDPageQuery
+  twoDPageQuery,
+  staticContent,
 };

--- a/webapp/src/styles/main.scss
+++ b/webapp/src/styles/main.scss
@@ -28,6 +28,11 @@ body {
   font-size: 14px;
 }
 
+a {
+  text-decoration: underline;
+  cursor: pointer;
+}
+
 .main {
   .page {
     height: 100vh;

--- a/webapp/src/styles/ui-components.scss
+++ b/webapp/src/styles/ui-components.scss
@@ -302,10 +302,9 @@
 
 }
 
-.datatable {
+.load-container {
   width: 100%;
   height: 100%;
-  overflow: hidden;
   position: absolute;
 }
 
@@ -548,10 +547,15 @@ input.invalid {
   .icon {
     min-width: 20px;
     color: darkgrey;
-    font-size: 14px;
+    font-size: 20px;
     padding-left: 3px;
     padding-right: 3px;
   }
+    .icon.info {
+    font-size: 14px;
+
+  }
+
   .icon:hover {
     color: #4e4e4e;
   }


### PR DESCRIPTION
Uses the same location in source files as 1.6.2, but adds the capability to embed any panoptes component in a file. Also adds title mechanism via `<title>` tag in the HTML fragment file.
Satisfies #544