### PR TITLE
Shorten displayNames for better HTML in templates etc

### DIFF
--- a/sampledata/datasets/Samples_and_Variants/settings
+++ b/sampledata/datasets/Samples_and_Variants/settings
@@ -14,10 +14,10 @@ description: |
   to documentation part of this deployment.
   <p>Some buttons that open popups:</p>
   <PopupButton label="Plot of Variants" icon="area-chart">
-    <TablePlotWidget plotType="scatter" table="variants" horizontal="Value1" vertical="Value2" />
+    <TablePlot plotType="scatter" table="variants" horizontal="Value1" vertical="Value2" />
   </PopupButton>
   <PopupButton label="Map of sites" icon="globe">
-    <TableMapWidget table="samplingsites" />
+    <TableMap table="samplingsites" />
   </PopupButton>
   <PopupButton label="Tree of samples" icon="tree">
     <TreeContainer table="samples" tree="tree2" />
@@ -35,49 +35,49 @@ description: |
   </div>
   <p>A plot of variants:</p>
   <div style="position:relative;width:300px;height:300px">
-  <TablePlotWidget plotType="scatter" table="variants" horizontal="Value1" vertical="Value2" />
+  <TablePlot plotType="scatter" table="variants" horizontal="Value1" vertical="Value2" />
   </div>
   <p>A complex map:</p>
   <div style="width:300px;height:300px">
-  <MapWidget center='{"lat": 1, "lng": -1.1}' zoom="2">
-    <LayersControlWidget position="topright">
-      <BaseLayerWidget checked name="OpenStreetMap.Mapnik">
-        <TileLayerWidget attribution="FIXME" url="http://{s}.tile.osm.org/{z}/{x}/{y}.png" />
-      </BaseLayerWidget>
-      <BaseLayerWidget name="OpenStreetMap.BlackAndWhite">
-        <FeatureGroupWidget>
-          <TileLayerWidget attribution="FIXME" url="http://{s}.tiles.wmflabs.org/bw-mapnik/{z}/{x}/{y}.png" />
-          <FeatureGroupWidget>
-            <MarkerWidget position='{"lat":0, "lng":0}'>
-              <PopupWidget><div><span>A pretty CSS3 popup. <br /> Easily customizable.</span></div></PopupWidget>
-            </MarkerWidget>
-            <MarkerWidget position='{"lat":50, "lng":0}'>
-              <PopupWidget><div><span>A pretty CSS3 popup. <br /> Easily customizable.</span></div></PopupWidget>
-            </MarkerWidget>
-          </FeatureGroupWidget>
-        </FeatureGroupWidget>
-      </BaseLayerWidget>
-      <OverlayWidget name="Sampling Sites">
-        <TableMarkersLayerWidget table="samplingsites" />
-      </OverlayWidget>
-      <OverlayWidget checked name="Layer group with circles">
-        <FeatureGroupWidget>
-          <CircleWidget center='{"lat":0, "lng":0}' fillColor="blue" radius="200" />
-          <CircleWidget center='{"lat":0, "lng":0}' fillColor="red" radius="100" stroke="false" />
-          <FeatureGroupWidget>
-            <CircleWidget center='{"lat":51.51, "lng":-0.08}' color="green" fillColor="green" radius="100" />
-          </FeatureGroupWidget>
-        </FeatureGroupWidget>
-      </OverlayWidget>
-      <OverlayWidget name="Feature group">
-        <FeatureGroupWidget color="purple">
-          <PopupWidget><span>Popup in FeatureGroup</span></PopupWidget>
-          <CircleWidget center='{"lat":51.51, "lng":-0.06}' radius="200" />
-          <RectangleWidget bounds='[{"lat":51.49, "lng":-0.08},{"lat":51.5, "lng":-0.06}]' />
-        </FeatureGroupWidget>
-      </OverlayWidget>
-    </LayersControlWidget>
-  </MapWidget>
+  <Map center='{"lat": 1, "lng": -1.1}' zoom="2">
+    <LayersControl position="topright">
+      <BaseLayer checked name="OpenStreetMap.Mapnik">
+        <TileLayer attribution="FIXME" url="http://{s}.tile.osm.org/{z}/{x}/{y}.png" />
+      </BaseLayer>
+      <BaseLayer name="OpenStreetMap.BlackAndWhite">
+        <FeatureGroup>
+          <TileLayer attribution="FIXME" url="http://{s}.tiles.wmflabs.org/bw-mapnik/{z}/{x}/{y}.png" />
+          <FeatureGroup>
+            <Marker position='{"lat":0, "lng":0}'>
+              <MapPopup><div><span>A pretty CSS3 popup. <br /> Easily customizable.</span></div></MapPopup>
+            </Marker>
+            <Marker position='{"lat":50, "lng":0}'>
+              <MapPopup><div><span>A pretty CSS3 popup. <br /> Easily customizable.</span></div></MapPopup>
+            </Marker>
+          </FeatureGroup>
+        </FeatureGroup>
+      </BaseLayer>
+      <Overlay name="Sampling Sites">
+        <TableMarkersLayer table="samplingsites" />
+      </Overlay>
+      <Overlay checked name="Layer group with circles">
+        <FeatureGroup>
+          <Circle center='{"lat":0, "lng":0}' fillColor="blue" radius="200" />
+          <Circle center='{"lat":0, "lng":0}' fillColor="red" radius="100" stroke="false" />
+          <FeatureGroup>
+            <Circle center='{"lat":51.51, "lng":-0.08}' color="green" fillColor="green" radius="100" />
+          </FeatureGroup>
+        </FeatureGroup>
+      </Overlay>
+      <Overlay name="Feature group">
+        <FeatureGroup color="purple">
+          <MapPopup><span>MapPopup in FeatureGroup</span></MapPopup>
+          <Circle center='{"lat":51.51, "lng":-0.06}' radius="200" />
+          <Rectangle bounds='[{"lat":51.49, "lng":-0.08},{"lat":51.5, "lng":-0.06}]' />
+        </FeatureGroup>
+      </Overlay>
+    </LayersControl>
+  </Map>
   </div>
 
 # Optional: a list of all the data table identifiers in the dataset

--- a/webapp/src/js/actions/PanoptesActions.js
+++ b/webapp/src/js/actions/PanoptesActions.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Constants from '../constants/Constants';
 import DataItemViews from 'panoptes/DataItemViews';
-import DataItemWidget from 'components/DataItem/Widget';
+import DataItem from 'components/DataItem/Widget';
 import serialiseComponent from 'util/serialiseComponent';
 const SESSION = Constants.SESSION;
 
@@ -14,9 +14,9 @@ const PanoptesActions = (config) => ({
     let views = DataItemViews.getViews(tableDataItemViews, config.tablesById[table].hasGeoCoord);
     this.dispatch(SESSION.POPUP_OPEN, {
       component: serialiseComponent(
-        <DataItemWidget table={table} primKey={primKey}>
+        <DataItem table={table} primKey={primKey}>
           {views}
-        </DataItemWidget>
+        </DataItem>
       ),
       switchTo
     });

--- a/webapp/src/js/components/Chart/Pie/Widget.js
+++ b/webapp/src/js/components/Chart/Pie/Widget.js
@@ -6,9 +6,9 @@ import PureRenderMixin from 'mixins/PureRenderMixin';
 import FluxMixin from 'mixins/FluxMixin';
 
 // Panoptes components
-import PieChartSectorWidget from 'Chart/Pie/Sector/Widget';
+import PieChartSector from 'Chart/Pie/Sector/Widget';
 
-let PieChartWidget = React.createClass({
+let PieChart = React.createClass({
 
   mixins: [
     PureRenderMixin,
@@ -54,7 +54,7 @@ let PieChartWidget = React.createClass({
     let outerRadius = crs.project({lat: 0, lng: radius}).x - crs.project({lat: 0, lng: 0}).x;
 
     let sectors = sectorsData.map((sectorData, i) =>
-        <PieChartSectorWidget
+        <PieChartSector
           key={i}
           arcDescriptor={arcDescriptors[i]}
           outerRadius={outerRadius}
@@ -92,4 +92,4 @@ let PieChartWidget = React.createClass({
 
 });
 
-module.exports = PieChartWidget;
+module.exports = PieChart;

--- a/webapp/src/js/components/DataItem/Widget.js
+++ b/webapp/src/js/components/DataItem/Widget.js
@@ -12,7 +12,7 @@ import TabbedArea from 'ui/TabbedArea';
 import TabPane from 'ui/TabPane';
 import DataItemActions from 'DataItem/Actions';
 
-let DataItemWidget = React.createClass({
+let DataItem = React.createClass({
 
   mixins: [
     PureRenderMixin,
@@ -75,4 +75,4 @@ let DataItemWidget = React.createClass({
 
 });
 
-module.exports = DataItemWidget;
+module.exports = DataItem;

--- a/webapp/src/js/components/FieldList/Widget.js
+++ b/webapp/src/js/components/FieldList/Widget.js
@@ -18,7 +18,7 @@ import ErrorReport from 'panoptes/ErrorReporter';
 // UI components
 import Loading from 'ui/Loading';
 
-let FieldListWidget = React.createClass({
+let FieldList = React.createClass({
 
   mixins: [
     PureRenderMixin,
@@ -117,4 +117,4 @@ let FieldListWidget = React.createClass({
 
 });
 
-module.exports = FieldListWidget;
+module.exports = FieldList;

--- a/webapp/src/js/components/Map/Actions.js
+++ b/webapp/src/js/components/Map/Actions.js
@@ -21,20 +21,20 @@ import SelectField from 'material-ui/SelectField';
 import TextField from 'material-ui/TextField';
 
 // Panoptes
-import BaseLayerWidget from 'Map/BaseLayer/Widget';
+import BaseLayer from 'Map/BaseLayer/Widget';
 import FilterButton from 'panoptes/FilterButton';
 import Icon from 'ui/Icon';
-import ImageOverlayWidget from 'Map/ImageOverlay/Widget';
-import LayersControlWidget from 'Map/LayersControl/Widget';
-import MapWidget from 'Map/Widget';
-import OverlayWidget from 'Map/Overlay/Widget';
+import ImageOverlay from 'Map/ImageOverlay/Widget';
+import LayersControl from 'Map/LayersControl/Widget';
+import Map from 'Map/Widget';
+import Overlay from 'Map/Overlay/Widget';
 import QueryString from 'panoptes/QueryString';
 import SelectFieldWithNativeFallback from 'panoptes/SelectFieldWithNativeFallback';
 import SidebarHeader from 'ui/SidebarHeader';
 import SQL from 'panoptes/SQL';
-import TableMapWidget from 'Map/Table/Widget';
-import TableMarkersLayerWidget from 'Map/TableMarkersLayer/Widget';
-import TileLayerWidget from 'Map/TileLayer/Widget';
+import TableMap from 'Map/Table/Widget';
+import TableMarkersLayer from 'Map/TableMarkersLayer/Widget';
+import TileLayer from 'Map/TileLayer/Widget';
 
 import 'map.scss';
 
@@ -305,12 +305,12 @@ let MapActions = React.createClass({
     if (table !== undefined && table !== DEFAULT_MARKER_LAYER) {
       // NB: This might not be used, if/when only a table has been selected.
       markersLayerComponent = (
-        <OverlayWidget
+        <Overlay
           checked={true}
           name={this.config.tablesById[table].capNamePlural}
         >
-          <TableMarkersLayerWidget locationDataTable={table} />
-        </OverlayWidget>
+          <TableMarkersLayer locationDataTable={table} />
+        </Overlay>
       );
     }
 
@@ -320,12 +320,12 @@ let MapActions = React.createClass({
       baseTileLayerProps.zIndex = baseTileLayerProps.zIndex !== undefined ? baseTileLayerProps.zIndex : 1;
 
       baseLayerComponent = (
-        <BaseLayerWidget
+        <BaseLayer
           checked={true}
           name={baseTileLayerProps.name}
         >
-          <TileLayerWidget {...baseTileLayerProps} />
-        </BaseLayerWidget>
+          <TileLayer {...baseTileLayerProps} />
+        </BaseLayer>
       );
     }
 
@@ -356,12 +356,12 @@ let MapActions = React.createClass({
         overlayLayerProps.zIndex = overlayLayerProps.zIndex !== undefined ? overlayLayerProps.zIndex : 2;
 
         overlayLayerComponent = (
-          <OverlayWidget
+          <Overlay
             checked={true}
             name={this.config.mapLayers[overlayLayer].name}
           >
-            <TileLayerWidget {...overlayLayerProps} />
-          </OverlayWidget>
+            <TileLayer {...overlayLayerProps} />
+          </Overlay>
         );
 
       } else if (this.config.mapLayers[overlayLayer].format === "image") {
@@ -369,20 +369,20 @@ let MapActions = React.createClass({
         overlayLayerProps.url = '/panoptes/Maps/' + this.config.dataset + '/' + overlayLayer + '/data.png';
 
         overlayLayerComponent = (
-          <OverlayWidget
+          <Overlay
             checked={true}
             name={this.config.mapLayers[overlayLayer].name}
           >
-            <ImageOverlayWidget {...overlayLayerProps} />
-          </OverlayWidget>
+            <ImageOverlay {...overlayLayerProps} />
+          </Overlay>
         );
 
       }
 
     }
 
-    let mapWidget = (
-      <MapWidget
+    let map = (
+      <Map
         center={center}
         setProps={setProps}
         onChange={this.handleChangeMap}
@@ -392,8 +392,8 @@ let MapActions = React.createClass({
 
     if (markersLayerComponent) {
 
-      mapWidget = (
-        <TableMapWidget
+      map = (
+        <TableMap
           center={center}
           setProps={setProps}
           table={table}
@@ -409,27 +409,27 @@ let MapActions = React.createClass({
       // Use a default baseLayer
       if (!baseLayerComponent) {
         baseLayerComponent = (
-          <BaseLayerWidget
+          <BaseLayer
             checked={true}
           >
-            <TileLayerWidget zIndex="1" />
-          </BaseLayerWidget>
+            <TileLayer zIndex="1" />
+          </BaseLayer>
         );
       }
 
-      mapWidget = (
-        <MapWidget
+      map = (
+        <Map
           center={center}
           setProps={setProps}
           onChange={this.handleChangeMap}
           zoom={zoom}
         >
-          <LayersControlWidget>
+          <LayersControl>
             {baseLayerComponent}
             {overlayLayerComponent}
             {markersLayerComponent}
-          </LayersControlWidget>
-        </MapWidget>
+          </LayersControl>
+        </Map>
       );
 
     }
@@ -439,7 +439,7 @@ let MapActions = React.createClass({
     // Whereas we need markup like: center='{"lat": -0.7031073524364783, "lng": 1.40625}'
 
     // Wrap the map template code in a container with dimensions.
-    let templateCode = '<div style="width:300px;height:300px">' + jsxToString(mapWidget, {ignoreProps: ['setProps', 'onChange']}) + '</div>';
+    let templateCode = '<div style="width:300px;height:300px">' + jsxToString(map, {ignoreProps: ['setProps', 'onChange']}) + '</div>';
 
 
     let sidebarContent = (
@@ -516,7 +516,7 @@ let MapActions = React.createClass({
               : null}
           </div>
           <div className="grow map-content">
-            {mapWidget}
+            {map}
           </div>
         </div>
       </Sidebar>

--- a/webapp/src/js/components/Map/BaseLayer/Widget.js
+++ b/webapp/src/js/components/Map/BaseLayer/Widget.js
@@ -1,7 +1,6 @@
 import React from 'react';
 
-import {LayersControl} from 'react-leaflet';
-const {BaseLayer} = LayersControl;
+import {LayersControl as LeafletLayersControl} from 'react-leaflet';
 
 // Mixins
 import FluxMixin from 'mixins/FluxMixin';
@@ -9,11 +8,11 @@ import FluxMixin from 'mixins/FluxMixin';
 import filterChildren from 'util/filterChildren';
 
 const ALLOWED_CHILDREN = [
-  'TileLayerWidget',
-  'FeatureGroupWidget',
+  'TileLayer',
+  'FeatureGroup',
 ];
 
-let BaseLayerWidget = React.createClass({
+let BaseLayer = React.createClass({
 
   mixins: [
     FluxMixin
@@ -63,7 +62,7 @@ let BaseLayerWidget = React.createClass({
     }
 
     return (
-      <BaseLayer
+      <LeafletLayersControl.BaseLayer
         addBaseLayer={addBaseLayer}
         checked={checked}
         children={children}
@@ -77,4 +76,4 @@ let BaseLayerWidget = React.createClass({
 
 });
 
-module.exports = BaseLayerWidget;
+module.exports = BaseLayer;

--- a/webapp/src/js/components/Map/Chart/Pie/Widget.js
+++ b/webapp/src/js/components/Map/Chart/Pie/Widget.js
@@ -4,12 +4,12 @@ import React from 'react';
 import FluxMixin from 'mixins/FluxMixin';
 
 // Panoptes components
-import MapWidget from 'Map/Widget';
-import FeatureGroupWidget from 'Map/FeatureGroup/Widget';
-import TileLayerWidget from 'Map/TileLayer/Widget';
-import PieChartMarkersLayerWidget from 'Map/PieChartMarkersLayer/Widget';
+import Map from 'Map/Widget';
+import FeatureGroup from 'Map/FeatureGroup/Widget';
+import TileLayer from 'Map/TileLayer/Widget';
+import PieChartMarkersLayer from 'Map/PieChartMarkersLayer/Widget';
 
-let PieChartMapWidget = React.createClass({
+let PieChartMap = React.createClass({
 
   mixins: [
     FluxMixin
@@ -61,15 +61,15 @@ let PieChartMapWidget = React.createClass({
     let widgetStyle = {height: '100%'};
 
     return (
-      <MapWidget
+      <Map
         center={center}
         setProps={setProps}
         style={widgetStyle}
         zoom={zoom}
       >
-        <FeatureGroupWidget>
-          <TileLayerWidget />
-          <PieChartMarkersLayerWidget
+        <FeatureGroup>
+          <TileLayer />
+          <PieChartMarkersLayer
             locationDataTable={locationDataTable}
             chartDataTable={chartDataTable}
             componentColumns={componentColumns}
@@ -77,12 +77,12 @@ let PieChartMapWidget = React.createClass({
             locationSizeProperty={locationSizeProperty}
             primKey={primKey}
           />
-        </FeatureGroupWidget>
-      </MapWidget>
+        </FeatureGroup>
+      </Map>
     );
 
   }
 
 });
 
-module.exports = PieChartMapWidget;
+module.exports = PieChartMap;

--- a/webapp/src/js/components/Map/Circle/Widget.js
+++ b/webapp/src/js/components/Map/Circle/Widget.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import {Circle} from 'react-leaflet';
+import {Circle as LeafletCircle} from 'react-leaflet';
 
 // Mixins
 import FluxMixin from 'mixins/FluxMixin';
 
-let CircleWidget = React.createClass({
+let Circle = React.createClass({
 
   mixins: [
     FluxMixin
@@ -18,7 +18,7 @@ let CircleWidget = React.createClass({
   render() {
     let {center, radius} = this.props;
     return (
-      <Circle
+      <LeafletCircle
         children={null}
         center={center}
         radius={radius}
@@ -27,4 +27,4 @@ let CircleWidget = React.createClass({
   }
 });
 
-module.exports = CircleWidget;
+module.exports = Circle;

--- a/webapp/src/js/components/Map/ComponentMarker/Widget.js
+++ b/webapp/src/js/components/Map/ComponentMarker/Widget.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import DivIcon from 'Map/DivIcon/Widget';
-import MarkerWidget from 'Map/Marker/Widget';
+import Marker from 'Map/Marker/Widget';
 
 // Mixins
 import FluxMixin from 'mixins/FluxMixin';
 
-let ComponentMarkerWidget = React.createClass({
+let ComponentMarker = React.createClass({
 
   mixins: [
     FluxMixin
@@ -40,7 +40,7 @@ let ComponentMarkerWidget = React.createClass({
 
     if (children === undefined) {
       children = (
-          <MarkerWidget
+          <Marker
             alt={alt}
             children={children}
             layerContainer={layerContainer}
@@ -67,4 +67,4 @@ let ComponentMarkerWidget = React.createClass({
 
 });
 
-module.exports = ComponentMarkerWidget;
+module.exports = ComponentMarker;

--- a/webapp/src/js/components/Map/DivIcon/Widget.js
+++ b/webapp/src/js/components/Map/DivIcon/Widget.js
@@ -3,10 +3,10 @@ https://github.com/jgimbel/react-leaflet-div-icon/blob/master/div-icon.js
 */
 import {PropTypes, Children} from 'react';
 import {render, unmountComponentAtNode} from 'react-dom';
-import {DivIcon, marker} from 'leaflet';
+import {DivIcon as LeafletDivIcon, marker} from 'leaflet';
 import {MapLayer} from 'react-leaflet';
 
-export default class Divicon extends MapLayer {
+export default class DivIcon extends MapLayer {
   static propTypes = {
     opacity: PropTypes.number,
     zIndexOffset: PropTypes.number,
@@ -15,7 +15,7 @@ export default class Divicon extends MapLayer {
   componentWillMount() {
     super.componentWillMount();
     const {position, ...props} = this.props;
-    this.icon = new DivIcon(props);
+    this.icon = new LeafletDivIcon(props);
     this.leafletElement = marker(position, {icon: this.icon,  ...props});
     this.leafletElement.on('add', this.renderContent.bind(this));
     this.leafletElement.on('remove', this.removeContent.bind(this));

--- a/webapp/src/js/components/Map/FeatureGroup/Widget.js
+++ b/webapp/src/js/components/Map/FeatureGroup/Widget.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {FeatureGroup} from 'react-leaflet';
+import {FeatureGroup as LeafletFeatureGroup} from 'react-leaflet';
 
 // Mixins
 import FluxMixin from 'mixins/FluxMixin';
@@ -8,18 +8,18 @@ import FluxMixin from 'mixins/FluxMixin';
 import filterChildren from 'util/filterChildren';
 
 const ALLOWED_CHILDREN = [
-  'ComponentMarkerWidget',
-  'TableMarkersLayerWidget',
-  'MarkerWidget',
-  'CircleWidget',
-  'RectangleWidget',
-  'PopupWidget',
-  'FeatureGroupWidget',
-  'TileLayerWidget',
-  'PieChartMarkersLayerWidget'
+  'ComponentMarker',
+  'TableMarkersLayer',
+  'Marker',
+  'Circle',
+  'Rectangle',
+  'MapPopup',
+  'FeatureGroup',
+  'TileLayer',
+  'PieChartMarkersLayer'
 ];
 
-let FeatureGroupWidget = React.createClass({
+let FeatureGroup = React.createClass({
 
   mixins: [
     FluxMixin
@@ -54,7 +54,7 @@ let FeatureGroupWidget = React.createClass({
     children = filterChildren(this, children, ALLOWED_CHILDREN);
 
     return (
-      <FeatureGroup
+      <LeafletFeatureGroup
         children={children}
       />
     );
@@ -62,4 +62,4 @@ let FeatureGroupWidget = React.createClass({
 
 });
 
-module.exports = FeatureGroupWidget;
+module.exports = FeatureGroup;

--- a/webapp/src/js/components/Map/ImageOverlay/Widget.js
+++ b/webapp/src/js/components/Map/ImageOverlay/Widget.js
@@ -1,11 +1,11 @@
 import React from 'react';
 
-import {ImageOverlay} from 'react-leaflet';
+import {ImageOverlay as LeafletImageOverlay} from 'react-leaflet';
 
 // Mixins
 import FluxMixin from 'mixins/FluxMixin';
 
-let ImageOverlayWidget = React.createClass({
+let ImageOverlay = React.createClass({
 
   mixins: [
     FluxMixin
@@ -55,7 +55,7 @@ let ImageOverlayWidget = React.createClass({
     // by changing the key whenever those props change, thereby causing React to remount the component.
 
     return (
-      <ImageOverlay
+      <LeafletImageOverlay
         attribution={attribution}
         bounds={bounds}
         key={JSON.stringify({attribution, bounds})}
@@ -68,4 +68,4 @@ let ImageOverlayWidget = React.createClass({
 
 });
 
-module.exports = ImageOverlayWidget;
+module.exports = ImageOverlay;

--- a/webapp/src/js/components/Map/LayersControl/Widget.js
+++ b/webapp/src/js/components/Map/LayersControl/Widget.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {LayersControl} from 'react-leaflet';
+import {LayersControl as LeafletLayersControl} from 'react-leaflet';
 
 // Mixins
 import FluxMixin from 'mixins/FluxMixin';
@@ -9,11 +9,11 @@ import filterChildren from 'util/filterChildren';
 import _cloneDeep from 'lodash/cloneDeep';
 
 const ALLOWED_CHILDREN = [
-  'BaseLayerWidget',
-  'OverlayWidget'
+  'BaseLayer',
+  'Overlay'
 ];
 
-let LayersControlWidget = React.createClass({
+let LayersControl = React.createClass({
 
   mixins: [
     FluxMixin
@@ -52,7 +52,7 @@ let LayersControlWidget = React.createClass({
     children = filterChildren(this, children, ALLOWED_CHILDREN);
 
     return (
-      <LayersControl
+      <LeafletLayersControl
         autoZIndex={autoZIndex}
         children={children}
         removeLayer={removeLayer}
@@ -64,4 +64,4 @@ let LayersControlWidget = React.createClass({
 
 });
 
-module.exports = LayersControlWidget;
+module.exports = LayersControl;

--- a/webapp/src/js/components/Map/Marker/Widget.js
+++ b/webapp/src/js/components/Map/Marker/Widget.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Marker} from 'react-leaflet';
+import {Marker as LeafletMarker} from 'react-leaflet';
 
 // Mixins
 import FluxMixin from 'mixins/FluxMixin';
@@ -7,10 +7,10 @@ import FluxMixin from 'mixins/FluxMixin';
 import filterChildren from 'util/filterChildren';
 
 const ALLOWED_CHILDREN = [
-  'PopupWidget'
+  'MapPopup'
 ];
 
-let MarkerWidget = React.createClass({
+let Marker = React.createClass({
 
   mixins: [
     FluxMixin
@@ -57,7 +57,7 @@ let MarkerWidget = React.createClass({
     }
 
     return (
-      <Marker
+      <LeafletMarker
         position={position}
         onClick={onClick || (() => null)}
         alt={alt}
@@ -72,4 +72,4 @@ let MarkerWidget = React.createClass({
 
 });
 
-module.exports = MarkerWidget;
+module.exports = Marker;

--- a/webapp/src/js/components/Map/Overlay/Widget.js
+++ b/webapp/src/js/components/Map/Overlay/Widget.js
@@ -1,7 +1,6 @@
 import React from 'react';
 
-import {LayersControl} from 'react-leaflet';
-const {Overlay} = LayersControl;
+import {LayersControl as LeafletLayersControl} from 'react-leaflet';
 
 // Mixins
 import FluxMixin from 'mixins/FluxMixin';
@@ -9,17 +8,17 @@ import FluxMixin from 'mixins/FluxMixin';
 import filterChildren from 'util/filterChildren';
 
 const ALLOWED_CHILDREN = [
-  'CircleWidget',
-  'FeatureGroupWidget',
-  'ImageOverlayWidget',
-  'MarkerWidget',
-  'PopupWidget',
-  'RectangleWidget',
-  'TableMarkersLayerWidget',
-  'TileLayerWidget'
+  'Circle',
+  'FeatureGroup',
+  'ImageOverlay',
+  'Marker',
+  'MapPopup',
+  'Rectangle',
+  'TableMarkersLayer',
+  'TileLayer'
 ];
 
-let OverlayWidget = React.createClass({
+let Overlay = React.createClass({
 
   mixins: [
     FluxMixin
@@ -59,7 +58,7 @@ let OverlayWidget = React.createClass({
     children = filterChildren(this, children, ALLOWED_CHILDREN);
 
     return (
-      <Overlay
+      <LeafletLayersControl.Overlay
         addOverlay={addOverlay}
         checked={checked}
         children={React.Children.only(children)}
@@ -74,4 +73,4 @@ let OverlayWidget = React.createClass({
 
 });
 
-module.exports = OverlayWidget;
+module.exports = Overlay;

--- a/webapp/src/js/components/Map/PieChartMarkersLayer/Widget.js
+++ b/webapp/src/js/components/Map/PieChartMarkersLayer/Widget.js
@@ -8,13 +8,13 @@ import FluxMixin from 'mixins/FluxMixin';
 // Panoptes
 import API from 'panoptes/API';
 import CalcMapBounds from 'util/CalcMapBounds';
-import ComponentMarkerWidget from 'Map/ComponentMarker/Widget';
+import ComponentMarker from 'Map/ComponentMarker/Widget';
 import ErrorReport from 'panoptes/ErrorReporter';
-import FeatureGroupWidget from 'Map/FeatureGroup/Widget';
+import FeatureGroup from 'Map/FeatureGroup/Widget';
 import GeoLayouter from 'utils/GeoLayouter';
 import {latlngToMercatorXY} from 'util/WebMercator'; // TODO: Is there a Leaflet equivalent?
 import LRUCache from 'util/LRUCache';
-import PieChartWidget from 'Chart/Pie/Widget';
+import PieChart from 'Chart/Pie/Widget';
 
 // Lodash
 import _cloneDeep from 'lodash/cloneDeep';
@@ -23,7 +23,7 @@ import _filter from 'lodash/filter';
 import _map from 'lodash/map';
 import _sum from 'lodash/sum';
 
-let PieChartMarkersLayerWidget = React.createClass({
+let PieChartMarkersLayer = React.createClass({
 
   mixins: [
     FluxMixin,
@@ -296,19 +296,19 @@ let PieChartMarkersLayerWidget = React.createClass({
       <GeoLayouter nodes={markers}>
         {
           (renderNodes) =>
-          <FeatureGroupWidget
+          <FeatureGroup
             layerContainer={layerContainer}
             map={map}
           >
             {
               renderNodes.map(
                 (marker, i) =>
-                <ComponentMarkerWidget
+                <ComponentMarker
                   key={i}
                   position={{lat: marker.lat, lng: marker.lng}}
                   onClick={(e) => this.handleClickMarker(e, marker)}
                 >
-                  <PieChartWidget
+                  <PieChart
                     chartData={marker.chartData}
                     crs={crs}
                     key={i}
@@ -319,10 +319,10 @@ let PieChartMarkersLayerWidget = React.createClass({
                     originalLng={marker.lng}
                     radius={marker.radius}
                   />
-                </ComponentMarkerWidget>
+                </ComponentMarker>
               )
             }
-          </FeatureGroupWidget>
+          </FeatureGroup>
         }
       </GeoLayouter>
     );
@@ -331,4 +331,4 @@ let PieChartMarkersLayerWidget = React.createClass({
 
 });
 
-module.exports = PieChartMarkersLayerWidget;
+module.exports = PieChartMarkersLayer;

--- a/webapp/src/js/components/Map/Popup/Widget.js
+++ b/webapp/src/js/components/Map/Popup/Widget.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import {Popup} from 'react-leaflet';
+import {Popup as LeafletPopup} from 'react-leaflet';
 import filterChildren from 'util/filterChildren';
 
 // Mixins
 import FluxMixin from 'mixins/FluxMixin';
 
-let PopupWidget = React.createClass({
+let MapPopup = React.createClass({
 
   mixins: [
     FluxMixin
@@ -38,7 +38,7 @@ let PopupWidget = React.createClass({
   render() {
     let children = filterChildren(this, this.props.children);
     return (
-      <Popup
+      <LeafletPopup
         children={React.Children.only(children)}
       />
     );
@@ -47,4 +47,4 @@ let PopupWidget = React.createClass({
 
 });
 
-module.exports = PopupWidget;
+module.exports = MapPopup;

--- a/webapp/src/js/components/Map/Rectangle/Widget.js
+++ b/webapp/src/js/components/Map/Rectangle/Widget.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import {Rectangle} from 'react-leaflet';
+import {Rectangle as LeafletRectangle} from 'react-leaflet';
 
 // Mixins
 import FluxMixin from 'mixins/FluxMixin';
 
-let RectangleWidget = React.createClass({
+let Rectangle = React.createClass({
 
   mixins: [
     FluxMixin
@@ -16,11 +16,11 @@ let RectangleWidget = React.createClass({
 
   render() {
     return (
-      <Rectangle
+      <LeafletRectangle
         bounds={this.props.bounds}
       />
     );
   }
 });
 
-module.exports = RectangleWidget;
+module.exports = Rectangle;

--- a/webapp/src/js/components/Map/Table/Widget.js
+++ b/webapp/src/js/components/Map/Table/Widget.js
@@ -5,9 +5,9 @@ import ConfigMixin from 'mixins/ConfigMixin';
 import FluxMixin from 'mixins/FluxMixin';
 
 // Panoptes components
-import MapWidget from 'Map/Widget';
-import TileLayerWidget from 'Map/TileLayer/Widget';
-import TableMarkersLayerWidget from 'Map/TableMarkersLayer/Widget';
+import Map from 'Map/Widget';
+import TileLayer from 'Map/TileLayer/Widget';
+import TableMarkersLayer from 'Map/TableMarkersLayer/Widget';
 
 // NB: This is a void component; no children allowed.
 // Although, the components returned by this component may have children.
@@ -16,22 +16,22 @@ import TableMarkersLayerWidget from 'Map/TableMarkersLayer/Widget';
 
 <p>A map of sampling sites:</p>
 <div style="position:relative;width:300px;height:300px">
-<TableMapWidget table="samplingsites" />
+<TableMap table="samplingsites" />
 </div>
 
 <p>A map highlighting a sampling site:</p>
 <div style="position:relative;width:300px;height:300px">
-<TableMapWidget table="samplingsites" primKey="St04" />
+<TableMap table="samplingsites" primKey="St04" />
 </div>
 
 <p>A map highlighting UK sampling sites:</p>
 <div style="position:relative;width:300px;height:300px">
-<TableMapWidget table="samplingsites" highlight="Country:UK" />
+<TableMap table="samplingsites" highlight="Country:UK" />
 </div>
 
 */
 
-let TableMapWidget = React.createClass({
+let TableMap = React.createClass({
 
   mixins: [
     ConfigMixin,
@@ -82,25 +82,25 @@ let TableMapWidget = React.createClass({
     let widgetStyle = {height: '100%'};
 
     return (
-      <MapWidget
+      <Map
         center={center}
         setProps={setProps}
         onChange={onChange}
         style={widgetStyle}
         zoom={zoom}
       >
-        <TileLayerWidget />
-        <TableMarkersLayerWidget
+        <TileLayer />
+        <TableMarkersLayer
           highlight={highlight}
           locationDataTable={locationDataTable}
           primKey={primKey}
           query={query}
         />
-      </MapWidget>
+      </Map>
     );
 
   }
 
 });
 
-module.exports = TableMapWidget;
+module.exports = TableMap;

--- a/webapp/src/js/components/Map/TableMarkersLayer/Widget.js
+++ b/webapp/src/js/components/Map/TableMarkersLayer/Widget.js
@@ -6,16 +6,15 @@ import DataFetcherMixin from 'mixins/DataFetcherMixin';
 import FluxMixin from 'mixins/FluxMixin';
 
 // Panoptes
-// Panoptes
 import API from 'panoptes/API';
 import CalcMapBounds from 'util/CalcMapBounds';
-import ComponentMarkerWidget from 'Map/ComponentMarker/Widget';
+import ComponentMarker from 'Map/ComponentMarker/Widget';
 import ErrorReport from 'panoptes/ErrorReporter';
-import FeatureGroupWidget from 'Map/FeatureGroup/Widget';
+import FeatureGroup from 'Map/FeatureGroup/Widget';
 import LRUCache from 'util/LRUCache';
 import SQL from 'panoptes/SQL';
 
-let TableMarkersLayerWidget = React.createClass({
+let TableMarkersLayer = React.createClass({
 
   mixins: [
     FluxMixin,
@@ -215,7 +214,7 @@ let TableMarkersLayerWidget = React.createClass({
       if (marker.isHighlighted || len === 1) {
 
         markerWidgets.push(
-          <ComponentMarkerWidget
+          <ComponentMarker
             key={i}
             position={{lat: marker.lat, lng: marker.lng}}
             title={marker.title}
@@ -226,7 +225,7 @@ let TableMarkersLayerWidget = React.createClass({
       } else {
 
         markerWidgets.push(
-          <ComponentMarkerWidget
+          <ComponentMarker
             key={i}
             position={{lat: marker.lat, lng: marker.lng}}
             title={marker.title}
@@ -235,7 +234,7 @@ let TableMarkersLayerWidget = React.createClass({
             <svg height="12" width="12">
               <circle cx="6" cy="6" r="5" stroke="#1E1E1E" strokeWidth="1" fill="#3D8BD5" />
             </svg>
-          </ComponentMarkerWidget>
+          </ComponentMarker>
         );
 
       }
@@ -243,7 +242,7 @@ let TableMarkersLayerWidget = React.createClass({
     }
 
     return (
-      <FeatureGroupWidget
+      <FeatureGroup
         children={markerWidgets}
         layerContainer={layerContainer}
         map={map}
@@ -254,4 +253,4 @@ let TableMarkersLayerWidget = React.createClass({
 
 });
 
-module.exports = TableMarkersLayerWidget;
+module.exports = TableMarkersLayer;

--- a/webapp/src/js/components/Map/TileLayer/WMS/Widget.js
+++ b/webapp/src/js/components/Map/TileLayer/WMS/Widget.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {WMSTileLayer} from 'react-leaflet';
+import {WMSTileLayer as LeafletWMSTileLayer} from 'react-leaflet';
 
 // Mixins
 import FluxMixin from 'mixins/FluxMixin';
@@ -14,9 +14,9 @@ import FluxMixin from 'mixins/FluxMixin';
 
 */
 
-// TODO: Is crs passed on to WMSTileLayer automatically (from MapWidget) via context?
+// TODO: Is crs passed on to WMSTileLayer automatically (from Map) via context?
 
-let WMSTileLayerWidget = React.createClass({
+let WMSTileLayer = React.createClass({
 
   mixins: [
     FluxMixin
@@ -66,7 +66,7 @@ let WMSTileLayerWidget = React.createClass({
     // FIXME: How to handle double quotes inside double quotes inside single quotes (!) in descriptions in templates.
 
     return (
-      <WMSTileLayer
+      <LeafletWMSTileLayer
         attribution={attribution}
         children={undefined}
         format={format}
@@ -80,4 +80,4 @@ let WMSTileLayerWidget = React.createClass({
 
 });
 
-module.exports = WMSTileLayerWidget;
+module.exports = WMSTileLayer;

--- a/webapp/src/js/components/Map/TileLayer/Widget.js
+++ b/webapp/src/js/components/Map/TileLayer/Widget.js
@@ -1,11 +1,11 @@
 import React from 'react';
 
-import {TileLayer} from 'react-leaflet';
+import {TileLayer as LeafletTileLayer} from 'react-leaflet';
 
 // Mixins
 import FluxMixin from 'mixins/FluxMixin';
 
-let TileLayerWidget = React.createClass({
+let TileLayer = React.createClass({
 
   mixins: [
     FluxMixin
@@ -84,7 +84,7 @@ let TileLayerWidget = React.createClass({
     // errorTileUrl="/dist/mapTiles/invisible.png"
 
     return (
-      <TileLayer
+      <LeafletTileLayer
         {...adaptedProps}
         attribution={attribution}
         bounds={bounds}
@@ -108,4 +108,4 @@ let TileLayerWidget = React.createClass({
 
 });
 
-module.exports = TileLayerWidget;
+module.exports = TileLayer;

--- a/webapp/src/js/components/Overview/Widget.js
+++ b/webapp/src/js/components/Overview/Widget.js
@@ -18,7 +18,7 @@ import ErrorReport from 'panoptes/ErrorReporter';
 // UI components
 import Loading from 'ui/Loading';
 
-let OverviewWidget = React.createClass({
+let Overview = React.createClass({
 
   mixins: [
     PureRenderMixin,
@@ -98,4 +98,4 @@ let OverviewWidget = React.createClass({
 
 });
 
-module.exports = OverviewWidget;
+module.exports = Overview;

--- a/webapp/src/js/components/Plot/Table/Actions.js
+++ b/webapp/src/js/components/Plot/Table/Actions.js
@@ -23,7 +23,7 @@ import PropertySelector from 'panoptes/PropertySelector';
 
 // Panoptes
 import SQL from 'panoptes/SQL';
-import TablePlotWidget from 'Plot/Table/Widget';
+import TablePlot from 'Plot/Table/Widget';
 import QueryString from 'panoptes/QueryString';
 import {plotTypes, allDimensions} from 'panoptes/plotTypes';
 import SelectFieldWithNativeFallback from 'panoptes/SelectFieldWithNativeFallback';
@@ -140,7 +140,7 @@ let TablePlotActions = React.createClass({
             : null}
           </div>
           <div className="grow">
-            {table ? <TablePlotWidget {...this.props} /> : null}
+            {table ? <TablePlot {...this.props} /> : null}
           </div>
         </div>
       </Sidebar>

--- a/webapp/src/js/components/Plot/Table/Widget.js
+++ b/webapp/src/js/components/Plot/Table/Widget.js
@@ -4,7 +4,7 @@ import _filter from 'lodash/filter';
 import _map from 'lodash/map';
 import _reduce from 'lodash/reduce';
 
-import PlotWidget from 'Plot/Widget';
+import Plot from 'Plot/Widget';
 
 import PureRenderMixin from 'mixins/PureRenderMixin';
 import ConfigMixin from 'mixins/ConfigMixin';
@@ -22,7 +22,7 @@ import 'plot.scss';
 // CSS
 //TODO: import 'Plot/Table/widget-styles.scss';
 
-let TablePlotWidget = React.createClass({
+let TablePlot = React.createClass({
 
   mixins: [
     PureRenderMixin,
@@ -104,7 +104,7 @@ let TablePlotWidget = React.createClass({
     return (
       <div className="plot-container">
         { plotType ?
-          <PlotWidget className="plot"
+          <Plot className="plot"
                 plotType={plotType}
                 {...this.state}
           />
@@ -114,4 +114,4 @@ let TablePlotWidget = React.createClass({
   }
 });
 
-module.exports = TablePlotWidget;
+module.exports = TablePlot;

--- a/webapp/src/js/components/PropertyGroup/Widget.js
+++ b/webapp/src/js/components/PropertyGroup/Widget.js
@@ -17,7 +17,7 @@ import LRUCache from 'util/LRUCache';
 // UI components
 import Loading from 'ui/Loading';
 
-let PropertyGroupWidget = React.createClass({
+let PropertyGroup = React.createClass({
 
   mixins: [
     PureRenderMixin,
@@ -111,4 +111,4 @@ let PropertyGroupWidget = React.createClass({
 
 });
 
-module.exports = PropertyGroupWidget;
+module.exports = PropertyGroup;

--- a/webapp/src/js/components/Template/Widget.js
+++ b/webapp/src/js/components/Template/Widget.js
@@ -9,7 +9,7 @@ import ConfigMixin from 'mixins/ConfigMixin';
 import 'template.scss';
 
 
-let TemplateWidget = React.createClass({
+let Template = React.createClass({
 
   mixins: [
     PureRenderMixin,
@@ -39,4 +39,4 @@ let TemplateWidget = React.createClass({
   }
 });
 
-module.exports = TemplateWidget;
+module.exports = Template;

--- a/webapp/src/js/components/containers/ListWithActions.js
+++ b/webapp/src/js/components/containers/ListWithActions.js
@@ -18,7 +18,7 @@ import Icon from 'ui/Icon';
 // Panoptes
 import ListView from 'panoptes/ListView';
 import ItemTemplate from 'panoptes/ItemTemplate';
-import DataItemWidget from 'DataItem/Widget';
+import DataItem from 'DataItem/Widget';
 import DataDownloader from 'util/DataDownloader';
 import HTMLWithComponents from 'panoptes/HTMLWithComponents';
 import DataItemViews from 'panoptes/DataItemViews';
@@ -138,7 +138,7 @@ let ListWithActions = React.createClass({
 
     let dataItem = '';
     if (selectedPrimKey) {
-      dataItem = <DataItemWidget views={views} primKey={selectedPrimKey} {...this.props}/>; //We pass along all props as currently selected tab etc are stored here
+      dataItem = <DataItem views={views} primKey={selectedPrimKey} {...this.props}/>; //We pass along all props as currently selected tab etc are stored here
     }
 
     return (

--- a/webapp/src/js/panoptes/DataItemViews.js
+++ b/webapp/src/js/panoptes/DataItemViews.js
@@ -1,16 +1,16 @@
 import React from 'react';
-import OverviewWidget from 'Overview/Widget';
-import TableMapWidget from 'Map/Table/Widget';
-import PieChartMapWidget from 'Map/Chart/Pie/Widget';
-import FieldListWidget from 'FieldList/Widget';
-import PropertyGroupWidget from 'PropertyGroup/Widget';
-import TemplateWidget from 'Template/Widget';
+import Overview from 'Overview/Widget';
+import TableMap from 'Map/Table/Widget';
+import PieChartMap from 'Map/Chart/Pie/Widget';
+import FieldList from 'FieldList/Widget';
+import PropertyGroup from 'PropertyGroup/Widget';
+import Template from 'Template/Widget';
 
 function getViews(dataItemViews, hasGeoCoord) {
   /*eslint-disable react/display-name */
   const viewTypes = {
-    Overview: (dataItemView, key) => (<OverviewWidget title="Overview" key={key}/>),
-    PieChartMap: (dataItemView, key) => (<PieChartMapWidget
+    Overview: (dataItemView, key) => (<Overview title="Overview" key={key}/>),
+    PieChartMap: (dataItemView, key) => (<PieChartMap
       initCenter={[dataItemView.mapCenter.latitude, dataItemView.mapCenter.longitude]}
       componentColumns={dataItemView.componentColumns}
       locationDataTable={dataItemView.locationDataTable}
@@ -19,14 +19,14 @@ function getViews(dataItemViews, hasGeoCoord) {
       title={dataItemView.name}
       residualFractionName={dataItemView.residualFractionName}
       key={key} />),
-    ItemMap: (dataItemView, key) => (<TableMapWidget title={dataItemView.name} key={key} />),
-    TableMap: (dataItemView, key) => (<TableMapWidget title={dataItemView.name} key={key} />),
-    FieldList: (dataItemView, key) => (<FieldListWidget title={dataItemView.name} fields={dataItemView.fields} key={key} />),
-    PropertyGroup: (dataItemView, key) => (<PropertyGroupWidget
+    ItemMap: (dataItemView, key) => (<TableMap title={dataItemView.name} key={key} />),
+    TableMap: (dataItemView, key) => (<TableMap title={dataItemView.name} key={key} />),
+    FieldList: (dataItemView, key) => (<FieldList title={dataItemView.name} fields={dataItemView.fields} key={key} />),
+    PropertyGroup: (dataItemView, key) => (<PropertyGroup
       title={dataItemView.name || dataItemView.groupId} //TODO This should be name from group config
       propertyGroupId={dataItemView.groupId}
       key={key} />),
-    Template: (dataItemView, key) => (<TemplateWidget
+    Template: (dataItemView, key) => (<Template
       title={dataItemView.name}
       content={dataItemView.content}
       key={key} />)
@@ -36,10 +36,10 @@ function getViews(dataItemViews, hasGeoCoord) {
   const views = [];
   if (dataItemViews === undefined || dataItemViews === null) {
     // If there are no dataItemViews specified, then default to showing an Overview.
-    views.push(<OverviewWidget title="Overview" />);
+    views.push(<Overview title="Overview" />);
     if (hasGeoCoord) {
       // If there are no dataItemViews specified and this table hasGeoCoord, then default to showing a Map
-      views.push(<TableMapWidget title="Location" />);
+      views.push(<TableMap title="Location" />);
     }
   } else {
     dataItemViews.forEach((dataItemView, i) => {


### PR DESCRIPTION
Mostly removing `Widget` but PopupWidget became MapPopup to avoid the name clash with Popup.
Satisfies #515 