### PR TITLE
Add delay to region queries

### DIFF
--- a/webapp/src/js/panoptes/API.js
+++ b/webapp/src/js/panoptes/API.js
@@ -32,7 +32,7 @@ function _filterError(json) {
 }
 
 function filterAborted(xhr) {
-  if (xhr.status === 0 && xhr.readyState == 0)  //This seems to be the only way to detect the cancel
+  if (xhr == '__CANCELLED__' || (xhr.status === 0 && xhr.readyState == 0))  //This seems to be the only way to detect the cancel
     return ('__SUPERSEEDED__');
   else
     throw xhr;
@@ -65,6 +65,10 @@ function request(options, method = 'GET', data = null) {
     if (options.params[key] === null) {
       delete options.params[key];
     }
+  }
+  //Annoyingly qajax doesn't check for cancellation before it fires off the request
+  if (options.cancellation && options.cancellation.isFulfilled()) {
+    return Promise.reject('__CANCELLED__');
   }
   //We could use the shiny new Fetch API here - but as there is no "abort" for that currently we stick with qajax.
   return qajax(Object.assign(defaults, options))

--- a/webapp/src/js/util/PropertyRegionCache.js
+++ b/webapp/src/js/util/PropertyRegionCache.js
@@ -9,6 +9,7 @@ import _filter from 'lodash/filter';
 import _sumBy from 'lodash/sumBy';
 import _each from 'lodash/each';
 import _transform from 'lodash/transform';
+import Q from 'q';
 
 const seenBlocks = {};
 
@@ -91,14 +92,17 @@ function fetch(APIArgs, cacheArgs, blockLevel, blockIndex, cancellation) {
   return LRUCache.get(
     'propertyRegionCache' + method + JSON.stringify(APIArgs),
     (cacheCancellation) =>
-      API[method]({cancellation: cacheCancellation, ...APIArgs})
-        .then((block) => {
-          if (isBlockTooBig(block, blockLimit)) {
-            return {_blockStart: blockStart, _blockSize: blockSize, _tooBig: true, ...block};
-          } else {
-            return {_blockStart: blockStart, _blockSize: blockSize, ...(postProcessBlock ? postProcessBlock(block) : block)};
-          }
-        }),
+      //Delay a bit to let quickly cancelled queries not reach the server - a temporary measure until server cancels the DB query
+      Q.delay(500).then(() =>
+        API[method]({cancellation: cacheCancellation, ...APIArgs})
+            .then((block) => {
+              if (isBlockTooBig(block, blockLimit)) {
+                return {_blockStart: blockStart, _blockSize: blockSize, _tooBig: true, ...block};
+              } else {
+                return {_blockStart: blockStart, _blockSize: blockSize, ...(postProcessBlock ? postProcessBlock(block) : block)};
+              }
+            })
+      ),
     cancellation
   )
     .then((data) => {


### PR DESCRIPTION
Add 500ms before a query in the PropertyRegionCache gets sent down the wire.
Satisfies #580 