### PR TITLE
Only render updated components + correct export syntax

### DIFF
--- a/webapp/src/js/actions/APIActions.js
+++ b/webapp/src/js/actions/APIActions.js
@@ -93,4 +93,4 @@ let APIActions = {
 
 };
 
-module.exports = APIActions;
+export default APIActions;

--- a/webapp/src/js/actions/PanoptesActions.js
+++ b/webapp/src/js/actions/PanoptesActions.js
@@ -23,4 +23,4 @@ const PanoptesActions = (config) => ({
   }
 });
 
-module.exports = PanoptesActions;
+export default PanoptesActions;

--- a/webapp/src/js/actions/SessionActions.js
+++ b/webapp/src/js/actions/SessionActions.js
@@ -89,4 +89,4 @@ let SessionActions = {
 
 };
 
-module.exports = SessionActions;
+export default SessionActions;

--- a/webapp/src/js/components/Chart/Pie/Sector/Widget.js
+++ b/webapp/src/js/components/Chart/Pie/Sector/Widget.js
@@ -40,4 +40,4 @@ let PieChartSector = React.createClass({
   }
 });
 
-module.exports = PieChartSector;
+export default PieChartSector;

--- a/webapp/src/js/components/Chart/Pie/Widget.js
+++ b/webapp/src/js/components/Chart/Pie/Widget.js
@@ -91,4 +91,4 @@ let PieChart = React.createClass({
 
 });
 
-module.exports = PieChart;
+export default PieChart;

--- a/webapp/src/js/components/DataItem/Widget.js
+++ b/webapp/src/js/components/DataItem/Widget.js
@@ -75,4 +75,4 @@ let DataItem = React.createClass({
 
 });
 
-module.exports = DataItem;
+export default DataItem;

--- a/webapp/src/js/components/Dataset/ImportStatus/ItemView.js
+++ b/webapp/src/js/components/Dataset/ImportStatus/ItemView.js
@@ -90,4 +90,4 @@ let DatasetImportStatusItemView = React.createClass({
 
 });
 
-module.exports = DatasetImportStatusItemView;
+export default DatasetImportStatusItemView;

--- a/webapp/src/js/components/Dataset/ImportStatus/ListView.js
+++ b/webapp/src/js/components/Dataset/ImportStatus/ListView.js
@@ -127,4 +127,4 @@ let DatasetImportStatusListView = React.createClass({
 
 });
 
-module.exports = DatasetImportStatusListView;
+export default DatasetImportStatusListView;

--- a/webapp/src/js/components/Dataset/Manager/Actions.js
+++ b/webapp/src/js/components/Dataset/Manager/Actions.js
@@ -102,4 +102,4 @@ let DatasetManagerActions = React.createClass({
   }
 });
 
-module.exports = DatasetManagerActions;
+export default DatasetManagerActions;

--- a/webapp/src/js/components/FieldList/Widget.js
+++ b/webapp/src/js/components/FieldList/Widget.js
@@ -119,4 +119,4 @@ let FieldList = React.createClass({
 
 });
 
-module.exports = FieldList;
+export default FieldList;

--- a/webapp/src/js/components/Map/Actions.js
+++ b/webapp/src/js/components/Map/Actions.js
@@ -542,4 +542,4 @@ let MapActions = React.createClass({
   }
 });
 
-module.exports = MapActions;
+export default MapActions;

--- a/webapp/src/js/components/Map/BaseLayer/Widget.js
+++ b/webapp/src/js/components/Map/BaseLayer/Widget.js
@@ -76,4 +76,4 @@ let BaseLayer = React.createClass({
 
 });
 
-module.exports = BaseLayer;
+export default BaseLayer;

--- a/webapp/src/js/components/Map/Chart/Pie/Widget.js
+++ b/webapp/src/js/components/Map/Chart/Pie/Widget.js
@@ -85,4 +85,4 @@ let PieChartMap = React.createClass({
 
 });
 
-module.exports = PieChartMap;
+export default PieChartMap;

--- a/webapp/src/js/components/Map/Circle/Widget.js
+++ b/webapp/src/js/components/Map/Circle/Widget.js
@@ -27,4 +27,4 @@ let Circle = React.createClass({
   }
 });
 
-module.exports = Circle;
+export default Circle;

--- a/webapp/src/js/components/Map/ComponentMarker/Widget.js
+++ b/webapp/src/js/components/Map/ComponentMarker/Widget.js
@@ -85,4 +85,4 @@ let ComponentMarker = React.createClass({
 
 });
 
-module.exports = ComponentMarker;
+export default ComponentMarker;

--- a/webapp/src/js/components/Map/FeatureGroup/Widget.js
+++ b/webapp/src/js/components/Map/FeatureGroup/Widget.js
@@ -63,4 +63,4 @@ let FeatureGroup = React.createClass({
 
 });
 
-module.exports = FeatureGroup;
+export default FeatureGroup;

--- a/webapp/src/js/components/Map/ImageOverlay/Widget.js
+++ b/webapp/src/js/components/Map/ImageOverlay/Widget.js
@@ -68,4 +68,4 @@ let ImageOverlay = React.createClass({
 
 });
 
-module.exports = ImageOverlay;
+export default ImageOverlay;

--- a/webapp/src/js/components/Map/LayersControl/Widget.js
+++ b/webapp/src/js/components/Map/LayersControl/Widget.js
@@ -66,4 +66,4 @@ let LayersControl = React.createClass({
 
 });
 
-module.exports = LayersControl;
+export default LayersControl;

--- a/webapp/src/js/components/Map/Marker/Widget.js
+++ b/webapp/src/js/components/Map/Marker/Widget.js
@@ -78,4 +78,4 @@ let Marker = React.createClass({
 
 });
 
-module.exports = Marker;
+export default Marker;

--- a/webapp/src/js/components/Map/Overlay/Widget.js
+++ b/webapp/src/js/components/Map/Overlay/Widget.js
@@ -73,4 +73,4 @@ let Overlay = React.createClass({
 
 });
 
-module.exports = Overlay;
+export default Overlay;

--- a/webapp/src/js/components/Map/PieChartMarkersLayer/Widget.js
+++ b/webapp/src/js/components/Map/PieChartMarkersLayer/Widget.js
@@ -312,4 +312,4 @@ let PieChartMarkersLayer = React.createClass({
 
 });
 
-module.exports = PieChartMarkersLayer;
+export default PieChartMarkersLayer;

--- a/webapp/src/js/components/Map/Polyline.js
+++ b/webapp/src/js/components/Map/Polyline.js
@@ -23,4 +23,4 @@ let Polyline = React.createClass({
   }
 });
 
-module.exports = Polyline;
+export default Polyline;

--- a/webapp/src/js/components/Map/Popup/Widget.js
+++ b/webapp/src/js/components/Map/Popup/Widget.js
@@ -47,4 +47,4 @@ let MapPopup = React.createClass({
 
 });
 
-module.exports = MapPopup;
+export default MapPopup;

--- a/webapp/src/js/components/Map/Rectangle/Widget.js
+++ b/webapp/src/js/components/Map/Rectangle/Widget.js
@@ -23,4 +23,4 @@ let Rectangle = React.createClass({
   }
 });
 
-module.exports = Rectangle;
+export default Rectangle;

--- a/webapp/src/js/components/Map/Table/Widget.js
+++ b/webapp/src/js/components/Map/Table/Widget.js
@@ -105,4 +105,4 @@ let TableMap = React.createClass({
 
 });
 
-module.exports = TableMap;
+export default TableMap;

--- a/webapp/src/js/components/Map/TableMarkersLayer/Widget.js
+++ b/webapp/src/js/components/Map/TableMarkersLayer/Widget.js
@@ -249,4 +249,4 @@ let TableMarkersLayer = React.createClass({
 
 });
 
-module.exports = TableMarkersLayer;
+export default TableMarkersLayer;

--- a/webapp/src/js/components/Map/TileLayer/WMS/Widget.js
+++ b/webapp/src/js/components/Map/TileLayer/WMS/Widget.js
@@ -80,4 +80,4 @@ let WMSTileLayer = React.createClass({
 
 });
 
-module.exports = WMSTileLayer;
+export default WMSTileLayer;

--- a/webapp/src/js/components/Map/TileLayer/Widget.js
+++ b/webapp/src/js/components/Map/TileLayer/Widget.js
@@ -108,4 +108,4 @@ let TileLayer = React.createClass({
 
 });
 
-module.exports = TileLayer;
+export default TileLayer;

--- a/webapp/src/js/components/Map/Widget.js
+++ b/webapp/src/js/components/Map/Widget.js
@@ -368,4 +368,4 @@ let Map = React.createClass({
 
 });
 
-module.exports = Map;
+export default Map;

--- a/webapp/src/js/components/Overview/Widget.js
+++ b/webapp/src/js/components/Overview/Widget.js
@@ -101,4 +101,4 @@ let Overview = React.createClass({
 
 });
 
-module.exports = Overview;
+export default Overview;

--- a/webapp/src/js/components/Plot/Table/Actions.js
+++ b/webapp/src/js/components/Plot/Table/Actions.js
@@ -156,4 +156,4 @@ let TablePlotActions = React.createClass({
   }
 });
 
-module.exports = TablePlotActions;
+export default TablePlotActions;

--- a/webapp/src/js/components/Plot/Table/Widget.js
+++ b/webapp/src/js/components/Plot/Table/Widget.js
@@ -129,4 +129,4 @@ let TablePlot = React.createClass({
   }
 });
 
-module.exports = TablePlot;
+export default TablePlot;

--- a/webapp/src/js/components/Plot/Widget.js
+++ b/webapp/src/js/components/Plot/Widget.js
@@ -57,4 +57,4 @@ let Plot = React.createClass({
 
 });
 
-module.exports = Plot;
+export default Plot;

--- a/webapp/src/js/components/PropertyGroup/Widget.js
+++ b/webapp/src/js/components/PropertyGroup/Widget.js
@@ -113,4 +113,4 @@ let PropertyGroup = React.createClass({
 
 });
 
-module.exports = PropertyGroup;
+export default PropertyGroup;

--- a/webapp/src/js/components/Template/Widget.js
+++ b/webapp/src/js/components/Template/Widget.js
@@ -39,4 +39,4 @@ let Template = React.createClass({
   }
 });
 
-module.exports = Template;
+export default Template;

--- a/webapp/src/js/components/containers/ComponentStack.js
+++ b/webapp/src/js/components/containers/ComponentStack.js
@@ -22,4 +22,4 @@ let ComponentStack = React.createClass({
 
 });
 
-module.exports = ComponentStack;
+export default ComponentStack;

--- a/webapp/src/js/components/containers/DataTableWithActions.js
+++ b/webapp/src/js/components/containers/DataTableWithActions.js
@@ -465,4 +465,4 @@ let DataTableWithActions = React.createClass({
   }
 });
 
-module.exports = DataTableWithActions;
+export default DataTableWithActions;

--- a/webapp/src/js/components/containers/EmptyTab.js
+++ b/webapp/src/js/components/containers/EmptyTab.js
@@ -42,4 +42,4 @@ let EmptyTab = React.createClass({
   }
 });
 
-module.exports = EmptyTab;
+export default EmptyTab;

--- a/webapp/src/js/components/containers/ErrorTab.js
+++ b/webapp/src/js/components/containers/ErrorTab.js
@@ -29,4 +29,4 @@ let ErrorTab = React.createClass({
   }
 });
 
-module.exports = ErrorTab;
+export default ErrorTab;

--- a/webapp/src/js/components/containers/FindGene.js
+++ b/webapp/src/js/components/containers/FindGene.js
@@ -139,4 +139,4 @@ let FindGene = React.createClass({
 
 });
 
-module.exports = FindGene;
+export default FindGene;

--- a/webapp/src/js/components/containers/FindGeneByNameDesc.js
+++ b/webapp/src/js/components/containers/FindGeneByNameDesc.js
@@ -75,4 +75,4 @@ let FindGeneByNameDesc = React.createClass({
   }
 });
 
-module.exports = FindGeneByNameDesc;
+export default FindGeneByNameDesc;

--- a/webapp/src/js/components/containers/FindGeneByRegion.js
+++ b/webapp/src/js/components/containers/FindGeneByRegion.js
@@ -190,4 +190,4 @@ let FindGeneByRegion = React.createClass({
   }
 });
 
-module.exports = FindGeneByRegion;
+export default FindGeneByRegion;

--- a/webapp/src/js/components/containers/Finder.js
+++ b/webapp/src/js/components/containers/Finder.js
@@ -149,4 +149,4 @@ let Finder = React.createClass({
   }
 });
 
-module.exports = Finder;
+export default Finder;

--- a/webapp/src/js/components/containers/Gene.js
+++ b/webapp/src/js/components/containers/Gene.js
@@ -202,4 +202,4 @@
 
   });
 
-  module.exports = Gene;
+  export default Gene;

--- a/webapp/src/js/components/containers/GenomeBrowserWithActions.js
+++ b/webapp/src/js/components/containers/GenomeBrowserWithActions.js
@@ -222,4 +222,4 @@ let GenomeBrowserWithActions = React.createClass({
   }
 });
 
-module.exports = GenomeBrowserWithActions;
+export default GenomeBrowserWithActions;

--- a/webapp/src/js/components/containers/GroupedItemPicker.js
+++ b/webapp/src/js/components/containers/GroupedItemPicker.js
@@ -186,4 +186,4 @@ let GroupedItemPicker = React.createClass({
 
 });
 
-module.exports = GroupedItemPicker;
+export default GroupedItemPicker;

--- a/webapp/src/js/components/containers/ItemPicker.js
+++ b/webapp/src/js/components/containers/ItemPicker.js
@@ -185,4 +185,4 @@ let ItemPicker = React.createClass({
 
 });
 
-module.exports = ItemPicker;
+export default ItemPicker;

--- a/webapp/src/js/components/containers/ListWithActions.js
+++ b/webapp/src/js/components/containers/ListWithActions.js
@@ -166,4 +166,4 @@ let ListWithActions = React.createClass({
   }
 });
 
-module.exports = ListWithActions;
+export default ListWithActions;

--- a/webapp/src/js/components/containers/PivotTableWithActions.js
+++ b/webapp/src/js/components/containers/PivotTableWithActions.js
@@ -136,4 +136,4 @@ let PivotTableWithActions = React.createClass({
   }
 });
 
-module.exports = PivotTableWithActions;
+export default PivotTableWithActions;

--- a/webapp/src/js/components/containers/QueryPicker.js
+++ b/webapp/src/js/components/containers/QueryPicker.js
@@ -235,4 +235,4 @@ let QueryPicker = React.createClass({
 
 });
 
-module.exports = QueryPicker;
+export default QueryPicker;

--- a/webapp/src/js/components/containers/RecentlyFoundGenes.js
+++ b/webapp/src/js/components/containers/RecentlyFoundGenes.js
@@ -82,4 +82,4 @@ let RecentlyFoundGenes = React.createClass({
   }
 });
 
-module.exports = RecentlyFoundGenes;
+export default RecentlyFoundGenes;

--- a/webapp/src/js/components/containers/RecentlyUsedTableQueries.js
+++ b/webapp/src/js/components/containers/RecentlyUsedTableQueries.js
@@ -98,4 +98,4 @@ let RecentlyUsedTableQueries = React.createClass({
   }
 });
 
-module.exports = RecentlyUsedTableQueries;
+export default RecentlyUsedTableQueries;

--- a/webapp/src/js/components/containers/StartTab.js
+++ b/webapp/src/js/components/containers/StartTab.js
@@ -52,4 +52,4 @@ let StartTab = React.createClass({
   }
 });
 
-module.exports = StartTab;
+export default StartTab;

--- a/webapp/src/js/components/containers/StoredTableQueries.js
+++ b/webapp/src/js/components/containers/StoredTableQueries.js
@@ -154,4 +154,4 @@ let StoredTableQueries = React.createClass({
   }
 });
 
-module.exports = StoredTableQueries;
+export default StoredTableQueries;

--- a/webapp/src/js/components/containers/TreeContainer.js
+++ b/webapp/src/js/components/containers/TreeContainer.js
@@ -88,4 +88,4 @@ let TreeContainer = React.createClass({
 
 });
 
-module.exports = TreeContainer;
+export default TreeContainer;

--- a/webapp/src/js/components/containers/TreeWithActions.js
+++ b/webapp/src/js/components/containers/TreeWithActions.js
@@ -171,4 +171,4 @@ let TreeWithActions = React.createClass({
   }
 });
 
-module.exports = TreeWithActions;
+export default TreeWithActions;

--- a/webapp/src/js/components/panoptes/ComponentWrapper.js
+++ b/webapp/src/js/components/panoptes/ComponentWrapper.js
@@ -41,4 +41,4 @@ let ComponentWrapper = React.createClass({
 
 });
 
-module.exports = ComponentWrapper;
+export default ComponentWrapper;

--- a/webapp/src/js/components/panoptes/DataTableView.js
+++ b/webapp/src/js/components/panoptes/DataTableView.js
@@ -327,4 +327,4 @@ let DataTableView = React.createClass({
 
 });
 
-module.exports = DataTableView;
+export default DataTableView;

--- a/webapp/src/js/components/panoptes/GeneSearchResultsList.js
+++ b/webapp/src/js/components/panoptes/GeneSearchResultsList.js
@@ -167,4 +167,4 @@ let GeneSearchResultsList = React.createClass({
 
 });
 
-module.exports = GeneSearchResultsList;
+export default GeneSearchResultsList;

--- a/webapp/src/js/components/panoptes/GeoMarker.js
+++ b/webapp/src/js/components/panoptes/GeoMarker.js
@@ -47,4 +47,4 @@ let GeoMarker = React.createClass({
 
 });
 
-module.exports = GeoMarker;
+export default GeoMarker;

--- a/webapp/src/js/components/panoptes/ItemLink.js
+++ b/webapp/src/js/components/panoptes/ItemLink.js
@@ -41,4 +41,4 @@ let ItemLink = React.createClass({
 
 });
 
-module.exports = ItemLink;
+export default ItemLink;

--- a/webapp/src/js/components/panoptes/ItemTemplate.js
+++ b/webapp/src/js/components/panoptes/ItemTemplate.js
@@ -145,4 +145,4 @@ let ItemTemplate = React.createClass({
   }
 });
 
-module.exports = ItemTemplate;
+export default ItemTemplate;

--- a/webapp/src/js/components/panoptes/ListView.js
+++ b/webapp/src/js/components/panoptes/ListView.js
@@ -205,4 +205,4 @@ let ListView = React.createClass({
 
 });
 
-module.exports = ListView;
+export default ListView;

--- a/webapp/src/js/components/panoptes/PivotTableView.js
+++ b/webapp/src/js/components/panoptes/PivotTableView.js
@@ -404,4 +404,4 @@ let PivotTableView = React.createClass({
 
 });
 
-module.exports = PivotTableView;
+export default PivotTableView;

--- a/webapp/src/js/components/panoptes/PropertyCell.js
+++ b/webapp/src/js/components/panoptes/PropertyCell.js
@@ -81,4 +81,4 @@ let PropertyCell = React.createClass({
 
 });
 
-module.exports = PropertyCell;
+export default PropertyCell;

--- a/webapp/src/js/components/panoptes/PropertyHeader.js
+++ b/webapp/src/js/components/panoptes/PropertyHeader.js
@@ -58,4 +58,4 @@ let PropertyHeader = React.createClass({
 
 });
 
-module.exports = PropertyHeader;
+export default PropertyHeader;

--- a/webapp/src/js/components/panoptes/PropertyInput.js
+++ b/webapp/src/js/components/panoptes/PropertyInput.js
@@ -35,4 +35,4 @@ let PropertyInput = React.createClass({
 
 });
 
-module.exports = PropertyInput;
+export default PropertyInput;

--- a/webapp/src/js/components/panoptes/PropertyLegend.js
+++ b/webapp/src/js/components/panoptes/PropertyLegend.js
@@ -62,4 +62,4 @@ let PropertyLegend = React.createClass({
   }
 });
 
-module.exports = PropertyLegend;
+export default PropertyLegend;

--- a/webapp/src/js/components/panoptes/PropertyList.js
+++ b/webapp/src/js/components/panoptes/PropertyList.js
@@ -41,4 +41,4 @@ let PropertyList = React.createClass({
 
 });
 
-module.exports = PropertyList;
+export default PropertyList;

--- a/webapp/src/js/components/panoptes/PropertyListItem.js
+++ b/webapp/src/js/components/panoptes/PropertyListItem.js
@@ -48,4 +48,4 @@ let PropertyListItem = React.createClass({
 
 });
 
-module.exports = PropertyListItem;
+export default PropertyListItem;

--- a/webapp/src/js/components/panoptes/QueryEditor.js
+++ b/webapp/src/js/components/panoptes/QueryEditor.js
@@ -600,4 +600,4 @@ let QueryEditor = React.createClass({
 
 });
 
-module.exports = QueryEditor;
+export default QueryEditor;

--- a/webapp/src/js/components/panoptes/QueryString.js
+++ b/webapp/src/js/components/panoptes/QueryString.js
@@ -67,4 +67,4 @@ let QueryString = React.createClass({
 
 });
 
-module.exports = QueryString;
+export default QueryString;

--- a/webapp/src/js/components/panoptes/RegionGenesList.js
+++ b/webapp/src/js/components/panoptes/RegionGenesList.js
@@ -156,4 +156,4 @@ let RegionGenesList = React.createClass({
 
 });
 
-module.exports = RegionGenesList;
+export default RegionGenesList;

--- a/webapp/src/js/components/panoptes/SelectFieldWithNativeFallback.js
+++ b/webapp/src/js/components/panoptes/SelectFieldWithNativeFallback.js
@@ -220,4 +220,4 @@ let SelectFieldWithNativeFallback = React.createClass({
 
 });
 
-module.exports = SelectFieldWithNativeFallback;
+export default SelectFieldWithNativeFallback;

--- a/webapp/src/js/components/panoptes/SessionComponent.js
+++ b/webapp/src/js/components/panoptes/SessionComponent.js
@@ -1,0 +1,48 @@
+import React from  'react';
+import deserialiseComponent from 'util/deserialiseComponent';
+// Mixins
+import FluxMixin from 'mixins/FluxMixin';
+import PureRenderMixin from 'mixins/PureRenderMixin';
+import StoreWatchMixin from 'mixins/StoreWatchMixin';
+
+let SessionComponent = React.createClass({
+  mixins: [
+    FluxMixin,
+    PureRenderMixin,
+    StoreWatchMixin('SessionStore')],
+
+  propTypes: {
+    compId: React.PropTypes.string
+  },
+
+  getStateFromFlux(props) {
+    props = props || this.props;
+    return {
+      component: this.getFlux().store('SessionStore').getState().getIn(['components', props.compId])
+    };
+  },
+
+  title() {
+    return this.state.component.getIn(['props', 'title']) || this.refs.child.title()
+  },
+
+  icon() {
+    return this.state.component.getIn(['props', 'icon']) || this.refs.child.icon()
+  },
+
+  componentWillReceiveProps(nextProps) {
+    this.setState(this.getStateFromFlux(nextProps));
+  },
+
+  render() {
+    const {compId} = this.props;
+    const {component} = this.state;
+    let actions = this.getFlux().actions.session;
+    return React.cloneElement(deserialiseComponent(component, [compId], {
+      setProps: actions.componentSetProps,
+      replaceSelf: actions.componentReplace
+    }), {ref: 'child'});
+  }
+});
+
+export default SessionComponent;

--- a/webapp/src/js/components/panoptes/TableList.js
+++ b/webapp/src/js/components/panoptes/TableList.js
@@ -57,4 +57,4 @@ let TableList = React.createClass({
   }
 });
 
-module.exports = TableList;
+export default TableList;

--- a/webapp/src/js/components/panoptes/Tree.js
+++ b/webapp/src/js/components/panoptes/Tree.js
@@ -40,4 +40,4 @@ let Tree = React.createClass({
 
 });
 
-module.exports = Tree;
+export default Tree;

--- a/webapp/src/js/components/panoptes/ViewList.js
+++ b/webapp/src/js/components/panoptes/ViewList.js
@@ -81,4 +81,4 @@ let ViewList = React.createClass({
   }
 });
 
-module.exports = ViewList;
+export default ViewList;

--- a/webapp/src/js/components/panoptes/genome/Background.js
+++ b/webapp/src/js/components/panoptes/genome/Background.js
@@ -72,4 +72,4 @@ let Background = React.createClass({
 
 });
 
-module.exports = Background;
+export default Background;

--- a/webapp/src/js/components/panoptes/genome/Controls.js
+++ b/webapp/src/js/components/panoptes/genome/Controls.js
@@ -140,5 +140,5 @@ let Controls = React.createClass({
   }
 });
 
-module.exports = Controls;
+export default Controls;
 

--- a/webapp/src/js/components/panoptes/genome/GenomeBrowser.js
+++ b/webapp/src/js/components/panoptes/genome/GenomeBrowser.js
@@ -311,6 +311,6 @@ let GenomeBrowser = React.createClass({
   }
 });
 
-module.exports = GenomeBrowser;
+export default GenomeBrowser;
 
 

--- a/webapp/src/js/components/panoptes/genome/LoadingIndicator.js
+++ b/webapp/src/js/components/panoptes/genome/LoadingIndicator.js
@@ -98,4 +98,4 @@ let LoadingIndicator = React.createClass({
   }
 });
 
-module.exports = LoadingIndicator;
+export default LoadingIndicator;

--- a/webapp/src/js/components/panoptes/genome/tracks/CanvasGroupChannel.js
+++ b/webapp/src/js/components/panoptes/genome/tracks/CanvasGroupChannel.js
@@ -137,6 +137,6 @@ let CanvasGroupChannel = React.createClass({
 });
 
 
-module.exports = CanvasGroupChannel;
+export default CanvasGroupChannel;
 
 

--- a/webapp/src/js/components/panoptes/genome/tracks/CategoricalChannel.js
+++ b/webapp/src/js/components/panoptes/genome/tracks/CategoricalChannel.js
@@ -418,6 +418,6 @@ let CategoricalTrackControls = React.createClass({
 });
 
 
-module.exports = CategoricalChannel;
+export default CategoricalChannel;
 
 

--- a/webapp/src/js/components/panoptes/genome/tracks/ChannelWithConfigDrawer.js
+++ b/webapp/src/js/components/panoptes/genome/tracks/ChannelWithConfigDrawer.js
@@ -99,7 +99,7 @@ let ChannelWithConfigDrawer = React.createClass({
   }
 });
 
-module.exports = ChannelWithConfigDrawer;
+export default ChannelWithConfigDrawer;
 
 //          {this.props.onClose ? <Icon className="close" name="times" onClick={this.handleClose}/> : null}
 

--- a/webapp/src/js/components/panoptes/genome/tracks/GenomeScale.js
+++ b/webapp/src/js/components/panoptes/genome/tracks/GenomeScale.js
@@ -83,6 +83,6 @@ let GenomeScale = React.createClass({
   }
 });
 
-module.exports = GenomeScale;
+export default GenomeScale;
 
 

--- a/webapp/src/js/components/panoptes/genome/tracks/GenotypesChannel.js
+++ b/webapp/src/js/components/panoptes/genome/tracks/GenotypesChannel.js
@@ -581,6 +581,6 @@ const GenotypesLegend = React.createClass({
 
 });
 
-module.exports = GenotypesChannel;
+export default GenotypesChannel;
 
 

--- a/webapp/src/js/components/panoptes/genome/tracks/NumericalSummaryTrack.js
+++ b/webapp/src/js/components/panoptes/genome/tracks/NumericalSummaryTrack.js
@@ -290,4 +290,4 @@ let NumericalSummaryTrack = React.createClass({
 
 });
 
-module.exports = NumericalSummaryTrack;
+export default NumericalSummaryTrack;

--- a/webapp/src/js/components/panoptes/genome/tracks/NumericalTrackGroupChannel.js
+++ b/webapp/src/js/components/panoptes/genome/tracks/NumericalTrackGroupChannel.js
@@ -241,4 +241,4 @@ let NumericalTrackGroupControls = React.createClass({
 });
 
 
-module.exports = NumericalTrackGroupChannel;
+export default NumericalTrackGroupChannel;

--- a/webapp/src/js/components/panoptes/genome/tracks/PerRowIndicatorChannel.js
+++ b/webapp/src/js/components/panoptes/genome/tracks/PerRowIndicatorChannel.js
@@ -393,4 +393,4 @@ const PerRowIndicatorControls = React.createClass({
 
 });
 
-module.exports = PerRowIndicatorChannel;
+export default PerRowIndicatorChannel;

--- a/webapp/src/js/components/panoptes/genome/tracks/PerRowNumericalChannel.js
+++ b/webapp/src/js/components/panoptes/genome/tracks/PerRowNumericalChannel.js
@@ -460,4 +460,4 @@ let PerRowNumericalTrackControls = React.createClass({
 });
 
 
-module.exports = PerRowScaledSVGChannel;
+export default PerRowScaledSVGChannel;

--- a/webapp/src/js/components/panoptes/genome/tracks/ReferenceSequence.js
+++ b/webapp/src/js/components/panoptes/genome/tracks/ReferenceSequence.js
@@ -265,4 +265,4 @@ let Legend = () =>
 Legend.shouldComponentUpdate = () => false;
 
 
-module.exports = ReferenceSequence;
+export default ReferenceSequence;

--- a/webapp/src/js/components/panoptes/genome/tracks/ScaledSVGChannel.js
+++ b/webapp/src/js/components/panoptes/genome/tracks/ScaledSVGChannel.js
@@ -132,6 +132,6 @@ let ScaledSVGChannel = React.createClass({
 });
 
 
-module.exports = ScaledSVGChannel;
+export default ScaledSVGChannel;
 
 

--- a/webapp/src/js/components/panoptes/genome/tracks/YScale.js
+++ b/webapp/src/js/components/panoptes/genome/tracks/YScale.js
@@ -54,6 +54,6 @@ let YScale = React.createClass({
   }
 });
 
-module.exports = YScale;
+export default YScale;
 
 

--- a/webapp/src/js/components/ui/Alert.js
+++ b/webapp/src/js/components/ui/Alert.js
@@ -63,4 +63,4 @@ let Alert = React.createClass({
 
 });
 
-module.exports = Alert;
+export default Alert;

--- a/webapp/src/js/components/ui/Confirm.js
+++ b/webapp/src/js/components/ui/Confirm.js
@@ -79,4 +79,4 @@ let Confirm = React.createClass({
 
 });
 
-module.exports = Confirm;
+export default Confirm;

--- a/webapp/src/js/components/ui/Copy.js
+++ b/webapp/src/js/components/ui/Copy.js
@@ -87,4 +87,4 @@ let Copy = React.createClass({
 
 });
 
-module.exports = Copy;
+export default Copy;

--- a/webapp/src/js/components/ui/HelloWorld.js
+++ b/webapp/src/js/components/ui/HelloWorld.js
@@ -19,4 +19,4 @@ let HelloWorld = React.createClass({
 
 });
 
-module.exports = HelloWorld;
+export default HelloWorld;

--- a/webapp/src/js/components/ui/Icon.js
+++ b/webapp/src/js/components/ui/Icon.js
@@ -73,4 +73,4 @@ let Icon = React.createClass({
   }
 });
 
-module.exports = Icon;
+export default Icon;

--- a/webapp/src/js/components/ui/Loading.js
+++ b/webapp/src/js/components/ui/Loading.js
@@ -54,4 +54,4 @@ let Loading = React.createClass({
 
 });
 
-module.exports = Loading;
+export default Loading;

--- a/webapp/src/js/components/ui/Modal.js
+++ b/webapp/src/js/components/ui/Modal.js
@@ -106,4 +106,4 @@ let Modal = React.createClass({
   }
 });
 
-module.exports = Modal;
+export default Modal;

--- a/webapp/src/js/components/ui/NumericInput.js
+++ b/webapp/src/js/components/ui/NumericInput.js
@@ -63,5 +63,5 @@ let NumericInput = React.createClass({
   }
 });
 
-module.exports = NumericInput;
+export default NumericInput;
 

--- a/webapp/src/js/components/ui/Popup.js
+++ b/webapp/src/js/components/ui/Popup.js
@@ -141,4 +141,4 @@ let Popup = React.createClass({
 
 });
 
-module.exports = Popup;
+export default Popup;

--- a/webapp/src/js/components/ui/Popups.js
+++ b/webapp/src/js/components/ui/Popups.js
@@ -23,4 +23,4 @@ let Popups = React.createClass({
 
 });
 
-module.exports = Popups;
+export default Popups;

--- a/webapp/src/js/components/ui/SidebarHeader.js
+++ b/webapp/src/js/components/ui/SidebarHeader.js
@@ -28,4 +28,4 @@ let SidebarHeader = React.createClass({
   }
 });
 
-module.exports = SidebarHeader;
+export default SidebarHeader;

--- a/webapp/src/js/components/ui/TabPane.js
+++ b/webapp/src/js/components/ui/TabPane.js
@@ -61,4 +61,4 @@ let TabPane = React.createClass({
 
 });
 
-module.exports = TabPane;
+export default TabPane;

--- a/webapp/src/js/components/ui/TabbedArea.js
+++ b/webapp/src/js/components/ui/TabbedArea.js
@@ -171,4 +171,4 @@ let TabbedArea = React.createClass({
   }
 });
 
-module.exports = TabbedArea;
+export default TabbedArea;

--- a/webapp/src/js/components/ui/TooltipEllipsis.js
+++ b/webapp/src/js/components/ui/TooltipEllipsis.js
@@ -26,4 +26,4 @@ let TooltipEllipsis = React.createClass({
 
 });
 
-module.exports = TooltipEllipsis;
+export default TooltipEllipsis;

--- a/webapp/src/js/components/utils/DetectResize.js
+++ b/webapp/src/js/components/utils/DetectResize.js
@@ -32,4 +32,4 @@ let DetectResize = React.createClass({
   }
 });
 
-module.exports = DetectResize;
+export default DetectResize;

--- a/webapp/src/js/components/utils/GeoLayouter.js
+++ b/webapp/src/js/components/utils/GeoLayouter.js
@@ -141,4 +141,4 @@ let GeoLayouter = React.createClass({
   }
 });
 
-module.exports = GeoLayouter;
+export default GeoLayouter;

--- a/webapp/src/js/mixins/ConfigMixin.js
+++ b/webapp/src/js/mixins/ConfigMixin.js
@@ -27,4 +27,4 @@ let ConfigMixin = {
   }
 };
 
-module.exports = ConfigMixin;
+export default ConfigMixin;

--- a/webapp/src/js/mixins/DataFetcherMixin.js
+++ b/webapp/src/js/mixins/DataFetcherMixin.js
@@ -33,4 +33,4 @@ DataFetcherMixin.componentWillMount = function() {
     'mixins: [DataFetcherMixin("Prop1", "Prop2")]');
 };
 
-module.exports = DataFetcherMixin;
+export default DataFetcherMixin;

--- a/webapp/src/js/mixins/FluxMixin.js
+++ b/webapp/src/js/mixins/FluxMixin.js
@@ -7,4 +7,4 @@ FluxMixin.componentWillMount = function() {
   this.flux = this.getFlux();
 };
 
-module.exports = FluxMixin;
+export default FluxMixin;

--- a/webapp/src/js/mixins/PureRenderMixin.js
+++ b/webapp/src/js/mixins/PureRenderMixin.js
@@ -1,4 +1,4 @@
 import immutableRenderMixin from 'react-immutable-render-mixin';//This wrapper was here for react 0.13
 
 //We do this redirection to allow easy changes
-module.exports = immutableRenderMixin;
+export default immutableRenderMixin;

--- a/webapp/src/js/mixins/PureRenderWithRedirectedProps.js
+++ b/webapp/src/js/mixins/PureRenderWithRedirectedProps.js
@@ -34,4 +34,4 @@ let PureRenderWithRedirectedProps = function({check, redirect}) {
   };
 };
 
-module.exports = PureRenderWithRedirectedProps;
+export default PureRenderWithRedirectedProps;

--- a/webapp/src/js/mixins/StoreWatchMixin.js
+++ b/webapp/src/js/mixins/StoreWatchMixin.js
@@ -37,4 +37,4 @@ StoreWatchMixin.componentWillMount = function() {
     'mixins: [StoreWatchMixin("Store1", "Store2")]');
 };
 
-module.exports = StoreWatchMixin;
+export default StoreWatchMixin;

--- a/webapp/src/js/panoptes/API.js
+++ b/webapp/src/js/panoptes/API.js
@@ -3,7 +3,6 @@ import arrayBufferDecode from 'panoptes/arrayBufferDecode';
 import _keys from 'lodash/keys';
 import _forEach from 'lodash/forEach';
 import _isNumber from 'lodash/isNumber';
-import _map from 'lodash/map';
 import {assertRequired} from 'util/Assert';
 import SQL from 'panoptes/SQL';
 import DataDecoders from 'panoptes/DataDecoders';

--- a/webapp/src/js/panoptes/Base64.js
+++ b/webapp/src/js/panoptes/Base64.js
@@ -142,4 +142,4 @@ let Base64 = {
   }
 
 };
-module.exports = Base64;
+export default Base64;

--- a/webapp/src/js/panoptes/DataDecoders.js
+++ b/webapp/src/js/panoptes/DataDecoders.js
@@ -337,4 +337,4 @@ DataDecoders.Encoder.Create = function(info) {
 };
 
 
-module.exports = DataDecoders;
+export default DataDecoders;

--- a/webapp/src/js/panoptes/Deformatter.js
+++ b/webapp/src/js/panoptes/Deformatter.js
@@ -5,7 +5,7 @@ let DateTime2JD = function(date) {
 };
 
 
-module.exports = function(property, string) {
+export default function(property, string) {
   if (property.isBoolean) {
     return string === 'NULL' ? null : _indexOf(['Yes', 'yes', '1', 'true', 'True'], string) !== -1;
   }

--- a/webapp/src/js/panoptes/ErrorReporter.js
+++ b/webapp/src/js/panoptes/ErrorReporter.js
@@ -19,4 +19,4 @@ function errorNotify(flux, message, retryFunc) {
   flux.actions.session.notify(note);
 }
 
-module.exports = errorNotify;
+export default errorNotify;

--- a/webapp/src/js/panoptes/Formatter.js
+++ b/webapp/src/js/panoptes/Formatter.js
@@ -3,7 +3,7 @@ let JD2DateTime = function(JD) {
   return new Date((JD - 2440587.5) * 24 * 60 * 60 * 1000);
 };
 
-module.exports = function(property, value) {
+export default function(property, value) {
   if (property.isText) {
     return value === null ? '' : value;
   }

--- a/webapp/src/js/panoptes/InitialConfig.js
+++ b/webapp/src/js/panoptes/InitialConfig.js
@@ -24,4 +24,4 @@ let fetchInitialConfig = function(dataset) {
     .then((resp) => ({dataset, user: {isManager}, ...resp.config}));
 };
 
-module.exports = fetchInitialConfig;
+export default fetchInitialConfig;

--- a/webapp/src/js/panoptes/SQL.js
+++ b/webapp/src/js/panoptes/SQL.js
@@ -773,4 +773,4 @@ SQL.TableSort = function(icollist) {
 
 SQL.nullQuery = SQL.WhereClause.encode(SQL.WhereClause.Trivial());
 
-module.exports = SQL;
+export default SQL;

--- a/webapp/src/js/panoptes/SummarisationCache.js
+++ b/webapp/src/js/panoptes/SummarisationCache.js
@@ -124,4 +124,4 @@ let SummarisationCache = {
 };
 
 
-module.exports = SummarisationCache;
+export default SummarisationCache;

--- a/webapp/src/js/panoptes/TickWidth.js
+++ b/webapp/src/js/panoptes/TickWidth.js
@@ -1,2 +1,2 @@
-module.exports = (width, pixelWidth, tickPixelWidth) =>
+export default (width, pixelWidth, tickPixelWidth) =>
   Math.pow(5, Math.floor(Math.log(2 * (width / (pixelWidth / tickPixelWidth))) / 1.6094379124341003)); // 5^(floor(log5(2*x))) Gives nearest power of 5

--- a/webapp/src/js/stores/ConfigStore.js
+++ b/webapp/src/js/stores/ConfigStore.js
@@ -291,4 +291,4 @@ const ConfigStore = Fluxxor.createStore({
 
 });
 
-module.exports = ConfigStore;
+export default ConfigStore;

--- a/webapp/src/js/stores/PanoptesStore.js
+++ b/webapp/src/js/stores/PanoptesStore.js
@@ -35,4 +35,4 @@ let PanoptesStore = Fluxxor.createStore({
   }
 });
 
-module.exports = PanoptesStore;
+export default PanoptesStore;

--- a/webapp/src/js/stores/SessionStore.js
+++ b/webapp/src/js/stores/SessionStore.js
@@ -252,4 +252,4 @@ let SessionStore = Fluxxor.createStore({
 
 });
 
-module.exports = SessionStore;
+export default SessionStore;

--- a/webapp/src/js/util/AttrMap.js
+++ b/webapp/src/js/util/AttrMap.js
@@ -1,4 +1,4 @@
-module.exports = (array, attribute) => {
+export default (array, attribute) => {
   let out = {};
   array.forEach((entry) => out[entry[attribute]] = entry);
   return out;

--- a/webapp/src/js/util/LRUCache.js
+++ b/webapp/src/js/util/LRUCache.js
@@ -76,5 +76,5 @@ let LRUCache = {
   }
 };
 
-module.exports = LRUCache;
+export default LRUCache;
 

--- a/webapp/src/js/util/RequestContext.js
+++ b/webapp/src/js/util/RequestContext.js
@@ -20,4 +20,4 @@ class RequestContext {
 }
 
 
-module.exports = RequestContext;
+export default RequestContext;


### PR DESCRIPTION
By only retrieving the component state from the store at the per-component level, we avoid re-renders of the top level `<Panoptes>` component and all other components when only one changes.
Fixes #611

I also fixed the export syntax to be introspection friendly.