### PR TITLE
Use normalized mouse wheel for GenomeBrowser zoom

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -74,6 +74,7 @@
     "lodash": "^4.16.4",
     "lz-string": "git+https://github.com/benjeffery/lz-string.git",
     "material-ui": "^0.16.0",
+    "normalize-wheel": "^1.0.1",
     "performance-now": "^0.2.0",
     "q": "^1.4.1",
     "qajax": "^1.3.0",

--- a/webapp/src/js/components/panoptes/genome/GenomeBrowser.js
+++ b/webapp/src/js/components/panoptes/genome/GenomeBrowser.js
@@ -9,6 +9,7 @@ import _keys from 'lodash/keys';
 import d3 from 'd3';
 import scrollbarSize from 'scrollbar-size';
 import ValidComponentChildren from 'util/ValidComponentChildren';
+import normalizeWheel from 'normalize-wheel';
 
 import Hammer from 'react-hammerjs';
 import {Motion, spring} from 'react-motion';
@@ -162,7 +163,7 @@ let GenomeBrowser = React.createClass({
   handleMouseWheel(e) {
     if (!this.isEventInPanningArea(e))
       return;
-    this.handleZoom(e.clientX - offset(e.currentTarget).left, e.deltaY);
+    this.handleZoom(e.clientX - offset(e.currentTarget).left, normalizeWheel(e).pixelY);
     e.stopPropagation();
     e.preventDefault();
   },
@@ -314,5 +315,3 @@ let GenomeBrowser = React.createClass({
 });
 
 export default GenomeBrowser;
-
-


### PR DESCRIPTION
Addresses #685 for Firefox 49 (and Chrome 54)
Appears to also work for latest others: {Edge 14, IE 11, Opera 41, Safari 10} but is there a bad lag?

Implements:
https://www.npmjs.com/package/normalize-wheel

I wonder if there a more direct way to use `normalizeWheel(e)`, since we already use Fixed Data Table?