### PR TITLE
ToggleBox component

### DIFF
--- a/sampledata/datasets/Samples_and_Variants/doc/index.html
+++ b/sampledata/datasets/Samples_and_Variants/doc/index.html
@@ -42,9 +42,9 @@
             </Content>
 	    </CustomButton>
         <ToggleBox>
-            <Title>
+            <Caption>
                 <span>Title of hidden stuff<span>
-            </Title>
+            </Caption>
             <Content>
                 <span>I was hidden!</span>
             </Content>

--- a/sampledata/datasets/Samples_and_Variants/doc/index.html
+++ b/sampledata/datasets/Samples_and_Variants/doc/index.html
@@ -33,14 +33,22 @@
             <TreeContainer table="samples" tree="tree2"/>
         </PopupButton>
         <p>A custom button targeting a tab:</p>
-	<CustomButton target="tab">
+	    <CustomButton target="tab">
             <Anchor>
                 <span style="background-color: lightblue"><i class="fa fa-globe" /> Click here for the same thing</span>
             </Anchor>
             <Content>
                 <span><i class="fa fa-globe" /> The same thing</span>
             </Content>
-	</CustomButton>
+	    </CustomButton>
+        <ToggleBox>
+            <Title>
+                <span>Title of hidden stuff<span>
+            </Title>
+            <Content>
+                <span>I was hidden!</span>
+            </Content>
+        </ToggleBox>
         <p>A table, with styled headers</p>
         <div style="position:relative;height:150px">
             <PivotTableView table="variants" columnProperty="Extra_1" rowProperty="HighQuality"/>

--- a/webapp/src/js/components/panoptes/Content.js
+++ b/webapp/src/js/components/panoptes/Content.js
@@ -3,7 +3,7 @@ import PureRenderMixin from 'mixins/PureRenderMixin';
 import _isArray from 'lodash/isArray';
 import filterChildren from 'util/filterChildren';
 
-//Child of CustomButton
+//Child of CustomButton, ToggleBox
 
 let Content = React.createClass({
   mixins: [

--- a/webapp/src/js/components/ui/ToggleBox.js
+++ b/webapp/src/js/components/ui/ToggleBox.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import classNames from 'classnames';
+import PureRenderMixin from 'mixins/PureRenderMixin';
+import _assign from 'lodash/assign';
+
+let ToggleBox = React.createClass({
+  mixins: [PureRenderMixin],
+
+  propTypes: {
+  	isHidden: React.PropTypes.bool,
+    children: React.PropTypes.element // Needs to be two elements, which counts as 5 children in React?
+  },
+
+  getInitialState: function() {
+      return {
+          isHidden: true
+      };
+  },
+    
+  handleShow: function () {
+  	this.setState ( { isHidden: false } )
+  },
+  
+  handleHide: function () {
+  	this.setState ( { isHidden: true } )
+  },
+  
+  render() {
+	let title = this.props.children[1] ; // First element; title that is always shown
+	let payload = this.props.children[3] ; // Second element; payload that can be toggled
+	let v1 = this.state.isHidden ? 'block' : 'none' ;
+	let v2 = !this.state.isHidden ? 'block' : 'none' ;
+	
+  	return (
+  		<div>
+  		<div style={{display:'inline-block','vertical-align':'top',margin:'2px',cursor:'pointer','border-radius':'5px',border:'1px solid black',padding:'1px'}}>
+  			<div style={{display:v1}} onClick={this.handleShow}>+</div>
+  			<div style={{display:v2}} onClick={this.handleHide}>-</div>
+  		</div>
+  		<div style={{display:'inline-block','vertical-align':'top',margin:'2px'}}>
+  			<div>{title}</div>
+  			<div style={{display:v2}}>{payload}</div>
+  		</div>
+  		</div>
+  	) ;
+  }
+
+});
+
+export default ToggleBox;

--- a/webapp/src/js/components/ui/ToggleBox.js
+++ b/webapp/src/js/components/ui/ToggleBox.js
@@ -11,10 +11,11 @@ let ToggleBox = React.createClass({
     children: function(props, propName, componentName) {
       // Only accept a single child, of the appropriate type
       let children = filterChildren(this, React.Children.toArray(props[propName]));
-      if (!(children[0].type === "Caption" && children[1].type === Content))
+      if (!((children[0].type === "Caption" && children[1].type === Content) ||
+      (children[1].type === "Caption" && children[0].type === Content)))
         return new Error(
           '`' + componentName + '` ' +
-          'should have two children: one Caption followed by one Content'
+          'should have two children: one Caption and one Content'
         );
     }
   },
@@ -39,10 +40,12 @@ let ToggleBox = React.createClass({
     if (!((children[0].type === "Caption" && children[1].type === Content) ||
     (children[1].type === "Caption" && children[0].type === Content)))
     throw Error(
-      'ToggleBox should have two children: one Caption followed by one Content'
+      'ToggleBox should have two children: one Caption and one Content'
     );
 
-    let [title, content] = children;
+    let title = children[0].type === "Caption" ? children[0] : children[1];
+    let content = children[0].type === Content ? children[0] : children[1];
+
     let v1 = this.state.isHidden ? 'block' : 'none' ;
     let v2 = !this.state.isHidden ? 'block' : 'none' ;
 

--- a/webapp/src/js/components/ui/ToggleBox.js
+++ b/webapp/src/js/components/ui/ToggleBox.js
@@ -33,11 +33,13 @@ let ToggleBox = React.createClass({
 	
   	return (
   		<div>
-  		<div style={{display:'inline-block','vertical-align':'top',margin:'2px','text-align':'center',width:'1em',cursor:'pointer','border-radius':'5px',border:'1px solid black',padding:'1px'}} onClick={this.handleToggle}>
+  		<div style={{display:'table-cell','vertical-align':'top',margin:'2px','text-align':'center',width:'1em',padding:'1px'}}>
+  		<div style={{cursor:'pointer','border-radius':'5px',border:'1px solid black'}} onClick={this.handleToggle}>
   			<div style={{display:v1}}>+</div>
   			<div style={{display:v2}}>-</div>
   		</div>
-  		<div style={{display:'inline-block','vertical-align':'top',margin:'2px'}}>
+  		</div>
+  		<div style={{display:'table-cell','vertical-align':'top',margin:'2px'}}>
   			<div>{title}</div>
   			<div style={{display:v2}}>{payload}</div>
   		</div>

--- a/webapp/src/js/components/ui/ToggleBox.js
+++ b/webapp/src/js/components/ui/ToggleBox.js
@@ -48,13 +48,13 @@ let ToggleBox = React.createClass({
 
   	return (
   		<div>
-        <div style={{display:'table-cell','vertical-align':'top',margin:'2px','text-align':'center',width:'1em',padding:'1px'}}>
-          <div style={{cursor:'pointer','border-radius':'5px',border:'1px solid black'}} onClick={this.handleToggle}>
+        <div style={{display:'table-cell',verticalAlign:'top',margin:'2px',textAlign:'center',width:'1em',padding:'1px'}}>
+          <div style={{cursor:'pointer',borderRadius:'5px',border:'1px solid black'}} onClick={this.handleToggle}>
             <div style={{display:v1}}>+</div>
             <div style={{display:v2}}>-</div>
           </div>
         </div>
-        <div style={{display:'table-cell','vertical-align':'top',margin:'2px'}}>
+        <div style={{display:'table-cell',verticalAlign:'top',margin:'2px'}}>
           <div>{title.props.children}</div>
           <div style={{display:v2}}>{content}</div>
         </div>

--- a/webapp/src/js/components/ui/ToggleBox.js
+++ b/webapp/src/js/components/ui/ToggleBox.js
@@ -10,21 +10,21 @@ let ToggleBox = React.createClass({
   	isHidden: React.PropTypes.bool,
     children: React.PropTypes.element // Needs to be two elements, which counts as 5 children in React?
   },
+  
+  getDefaultProps: function () {
+    return { isHidden:true } ;
+  } ,
 
   getInitialState: function() {
       return {
-          isHidden: true
+          isHidden: this.props.isHidden
       };
   },
-    
-  handleShow: function () {
-  	this.setState ( { isHidden: false } )
+
+  handleToggle: function () {
+  	this.setState ( { isHidden: !this.state.isHidden } )
   },
-  
-  handleHide: function () {
-  	this.setState ( { isHidden: true } )
-  },
-  
+
   render() {
 	let title = this.props.children[1] ; // First element; title that is always shown
 	let payload = this.props.children[3] ; // Second element; payload that can be toggled
@@ -33,9 +33,9 @@ let ToggleBox = React.createClass({
 	
   	return (
   		<div>
-  		<div style={{display:'inline-block','vertical-align':'top',margin:'2px',cursor:'pointer','border-radius':'5px',border:'1px solid black',padding:'1px'}}>
-  			<div style={{display:v1}} onClick={this.handleShow}>+</div>
-  			<div style={{display:v2}} onClick={this.handleHide}>-</div>
+  		<div style={{display:'inline-block','vertical-align':'top',margin:'2px','text-align':'center',width:'1em',cursor:'pointer','border-radius':'5px',border:'1px solid black',padding:'1px'}} onClick={this.handleToggle}>
+  			<div style={{display:v1}}>+</div>
+  			<div style={{display:v2}}>-</div>
   		</div>
   		<div style={{display:'inline-block','vertical-align':'top',margin:'2px'}}>
   			<div>{title}</div>

--- a/webapp/src/js/components/ui/ToggleBox.js
+++ b/webapp/src/js/components/ui/ToggleBox.js
@@ -11,10 +11,10 @@ let ToggleBox = React.createClass({
     children: function(props, propName, componentName) {
       // Only accept a single child, of the appropriate type
       let children = filterChildren(this, React.Children.toArray(props[propName]));
-      if (!(children[0].type === "Title" && children[1].type === Content))
+      if (!(children[0].type === "Caption" && children[1].type === Content))
         return new Error(
           '`' + componentName + '` ' +
-          'should have two children: one Title followed by one Content'
+          'should have two children: one Caption followed by one Content'
         );
     }
   },
@@ -36,10 +36,10 @@ let ToggleBox = React.createClass({
   render() {
     let {children} = this.props;
     children = filterChildren(this, React.Children.toArray(children));
-    if (!((children[0].type === "Title" && children[1].type === Content) ||
-    (children[1].type === "Title" && children[0].type === Content)))
+    if (!((children[0].type === "Caption" && children[1].type === Content) ||
+    (children[1].type === "Caption" && children[0].type === Content)))
     throw Error(
-      'ToggleBox should have two children: one Title followed by one Content'
+      'ToggleBox should have two children: one Caption followed by one Content'
     );
 
     let [title, content] = children;

--- a/webapp/src/js/components/ui/ToggleBox.js
+++ b/webapp/src/js/components/ui/ToggleBox.js
@@ -1,16 +1,24 @@
 import React from 'react';
-import classNames from 'classnames';
 import PureRenderMixin from 'mixins/PureRenderMixin';
-import _assign from 'lodash/assign';
+import Content from 'panoptes/Content';
+import filterChildren from 'util/filterChildren';
 
 let ToggleBox = React.createClass({
   mixins: [PureRenderMixin],
 
   propTypes: {
   	isHidden: React.PropTypes.bool,
-    children: React.PropTypes.element // Needs to be two elements, which counts as 5 children in React?
+    children: function(props, propName, componentName) {
+      // Only accept a single child, of the appropriate type
+      let children = filterChildren(this, React.Children.toArray(props[propName]));
+      if (!(children[0].type === "Title" && children[1].type === Content))
+        return new Error(
+          '`' + componentName + '` ' +
+          'should have two children: one Title followed by one Content'
+        );
+    }
   },
-  
+
   getDefaultProps: function () {
     return { isHidden:true } ;
   } ,
@@ -26,23 +34,30 @@ let ToggleBox = React.createClass({
   },
 
   render() {
-	let title = this.props.children[1] ; // First element; title that is always shown
-	let payload = this.props.children[3] ; // Second element; payload that can be toggled
-	let v1 = this.state.isHidden ? 'block' : 'none' ;
-	let v2 = !this.state.isHidden ? 'block' : 'none' ;
-	
+    let {children} = this.props;
+    children = filterChildren(this, React.Children.toArray(children));
+    if (!((children[0].type === "Title" && children[1].type === Content) ||
+    (children[1].type === "Title" && children[0].type === Content)))
+    throw Error(
+      'ToggleBox should have two children: one Title followed by one Content'
+    );
+
+    let [title, content] = children;
+    let v1 = this.state.isHidden ? 'block' : 'none' ;
+    let v2 = !this.state.isHidden ? 'block' : 'none' ;
+
   	return (
   		<div>
-  		<div style={{display:'table-cell','vertical-align':'top',margin:'2px','text-align':'center',width:'1em',padding:'1px'}}>
-  		<div style={{cursor:'pointer','border-radius':'5px',border:'1px solid black'}} onClick={this.handleToggle}>
-  			<div style={{display:v1}}>+</div>
-  			<div style={{display:v2}}>-</div>
-  		</div>
-  		</div>
-  		<div style={{display:'table-cell','vertical-align':'top',margin:'2px'}}>
-  			<div>{title}</div>
-  			<div style={{display:v2}}>{payload}</div>
-  		</div>
+        <div style={{display:'table-cell','vertical-align':'top',margin:'2px','text-align':'center',width:'1em',padding:'1px'}}>
+          <div style={{cursor:'pointer','border-radius':'5px',border:'1px solid black'}} onClick={this.handleToggle}>
+            <div style={{display:v1}}>+</div>
+            <div style={{display:v2}}>-</div>
+          </div>
+        </div>
+        <div style={{display:'table-cell','vertical-align':'top',margin:'2px'}}>
+          <div>{title.props.children}</div>
+          <div style={{display:v2}}>{content}</div>
+        </div>
   		</div>
   	) ;
   }


### PR DESCRIPTION
This should fix #788. Needs two children passed, one title (always visible) and one toggle-able payload, both HTML-like. Example call:

```
<ToggleBox>
<div><QueryResult table="country_region" query='{"whcClass":"comparefixed","isCompound":false,"ColName":"region","CompValue":"$r","isRoot":true,"Tpe":"="}'/> countries in $r.</div>
<div>Blahblah</div>
</ToggleBox>
```
