### PR TITLE
Add ItemLink button type, make docimage: icon name type

### DIFF
--- a/webapp/src/js/components/Header.js
+++ b/webapp/src/js/components/Header.js
@@ -153,7 +153,7 @@ let Header = createReactClass({
                 </ListItem>
                 <ListItem button onClick={() => (this.handleCloseDrawer(), this.handleChangeTab(1))}>
                   <ListItemIcon>
-                    <Icon className="icon" baseURL="/panoptes/Docs/observatory/images/icons/" name="image:guidebook.svg" />
+                    <Icon className="icon" name="docimage:icons/guidebook.svg" />
                   </ListItemIcon>
                   <ListItemText primary="Guidebooks" />
                   {guidebooksIsExpanded ? <ExpandLess onClick={(event) => (event.stopPropagation(), this.handleToggleExpand('guidebooksIsExpanded'))}/> : <ExpandMore onClick={(event) => (event.stopPropagation(), this.handleToggleExpand('guidebooksIsExpanded'))}/>}
@@ -162,7 +162,7 @@ let Header = createReactClass({
                   <List component="div" disablePadding>
                     <ListItem button className={classes.nested} onClick={() => (this.handleCloseDrawer(), actions.session.tabOpen(<DocPage path="news.html"/>))}>
                       <ListItemIcon>
-                        <Icon className="icon" baseURL="/panoptes/Docs/observatory/images/icons/" name="image:stories-news.svg" />
+                        <Icon className="icon"  name="docimage:icons/stories-news.svg" />
                       </ListItemIcon>
                       <ListItemText primary="Articles" />
                     </ListItem>
@@ -170,7 +170,7 @@ let Header = createReactClass({
                   <List component="div" disablePadding>
                     <ListItem button className={classes.nested} onClick={() => (this.handleCloseDrawer(), actions.session.tabOpen(<DocPage path="pf.html"/>))}>
                       <ListItemIcon>
-                        <Icon className="icon" baseURL="/panoptes/Docs/observatory/images/icons/" name="image:plasmodium-falciparum.svg" />
+                        <Icon className="icon"  name="docimage:icons/plasmodium-falciparum.svg" />
                       </ListItemIcon>
                       <ListItemText primary="P. falciparum" />
                       {pfIsExpanded ? <ExpandLess onClick={(event) => (event.stopPropagation(), this.handleToggleExpand('pfIsExpanded'))}/> : <ExpandMore onClick={(event) => (event.stopPropagation(), this.handleToggleExpand('pfIsExpanded'))}/>}
@@ -180,19 +180,19 @@ let Header = createReactClass({
                     <List component="div" disablePadding>
                       <ListItem button className={classes.nested2} onClick={() => (this.handleCloseDrawer(), actions.session.tabOpen(<DocPage path="regions.html"/>))}>
                         <ListItemIcon>
-                          <Icon className="icon" baseURL="/panoptes/Docs/observatory/images/icons/" name="image:map.svg" />
+                          <Icon className="icon"  name="docimage:icons/map.svg" />
                         </ListItemIcon>
                         <ListItemText inset primary="Regions" />
                       </ListItem>
                       <ListItem button className={classes.nested2} onClick={() => (this.handleCloseDrawer(), actions.session.tabOpen(<DocPage path="drugs.html"/>))}>
                         <ListItemIcon>
-                          <Icon className="icon" baseURL="/panoptes/Docs/observatory/images/icons/" name="image:drug01.svg" />
+                          <Icon className="icon"  name="docimage:icons/drug01.svg" />
                         </ListItemIcon>
                         <ListItemText inset primary="Drugs" />
                       </ListItem>
                       <ListItem button className={classes.nested2} onClick={() => (this.handleCloseDrawer(), actions.session.tabOpen(<DocPage path="genes.html"/>))}>
                         <ListItemIcon>
-                          <Icon className="icon" baseURL="/panoptes/Docs/observatory/images/icons/" name="image:gene01.svg" />
+                          <Icon className="icon"  name="docimage:icons/gene01.svg" />
                         </ListItemIcon>
                         <ListItemText inset primary="Genes" />
                       </ListItem>
@@ -201,7 +201,7 @@ let Header = createReactClass({
                 </Collapse>
                 <ListItem button onClick={() => (this.handleCloseDrawer(), actions.session.tabOpen(<DocPage path="about.html"/>))}>
                   <ListItemIcon>
-                    <Icon className="icon" baseURL="/panoptes/Docs/observatory/images/icons/" name="image:table01.svg" />
+                    <Icon className="icon" name="docimage:icons/table01.svg" />
                   </ListItemIcon>
                   <ListItemText inset primary="Data" />
                 </ListItem>

--- a/webapp/src/js/components/panoptes/ItemLink.js
+++ b/webapp/src/js/components/panoptes/ItemLink.js
@@ -2,22 +2,27 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import createReactClass from 'create-react-class';
+import Button from 'ui/Button';
+import Icon from 'ui/Icon';
 
 // Mixins
 import PureRenderMixin from 'mixins/PureRenderMixin';
 import FluxMixin from 'mixins/FluxMixin';
+import ConfigMixin from "mixins/ConfigMixin";
 
 let ItemLink = createReactClass({
   displayName: 'ItemLink',
 
   mixins: [
     PureRenderMixin,
+    ConfigMixin,
     FluxMixin
   ],
 
   propTypes: {
     table: PropTypes.string,
-    primKey: PropTypes.string
+    primKey: PropTypes.string,
+    button: PropTypes.bool
   },
 
   handleClick(e) {
@@ -32,7 +37,7 @@ let ItemLink = createReactClass({
   // TODO: primKey might need formatting (using panoptes/Formatter) but would need property.isBoolean, etc.
 
   render() {
-    let {primKey, children} = this.props;
+    let {table, primKey, children, button} = this.props;
     if (!children) {
       return (
         <span
@@ -42,6 +47,10 @@ let ItemLink = createReactClass({
           {primKey}
         </span>
       );
+    } else if (button) {
+      return <Button onClick={(e) => this.handleClick(e)}
+                     icon={<Icon name={this.config.tablesById[table].icon} />}
+                     color="secondary" label={children} iconName="circle" raised="raised" target="popup"/>
     } else {
       return <span style={{cursor: 'pointer'}} onClick={(e) => this.handleClick(e)}>{children}</span>;
     }

--- a/webapp/src/js/components/ui/Icon.js
+++ b/webapp/src/js/components/ui/Icon.js
@@ -2,6 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import PureRenderMixin from 'mixins/PureRenderMixin';
+import FluxMixin from 'mixins/FluxMixin';
+import ConfigMixin from "mixins/ConfigMixin";
 
 import _startsWith from 'lodash.startswith';
 
@@ -11,7 +13,11 @@ const dynamicRequire = (path) => dynreq(`./${path}`);
 
 let Icon = createReactClass({
   displayName: 'Icon',
-  mixins: [PureRenderMixin],
+  mixins: [
+    PureRenderMixin,
+    ConfigMixin,
+    FluxMixin
+  ],
 
   propTypes: {
     name: PropTypes.string.isRequired,
@@ -69,8 +75,10 @@ let Icon = createReactClass({
     if (className) {
       classNames += ` ${className}`;
     }
-    if (_startsWith(name, 'bitmap:') || _startsWith(name, 'image:')) {
-      const fileName = _startsWith(name, 'bitmap:') ? name.substring(7) : name.substring(6);
+    if (_startsWith(name, 'docimage:'))
+      baseURL = `/panoptes/Docs/${this.config.dataset}/images/`;
+    if (_startsWith(name, 'bitmap:') || _startsWith(name, 'image:')|| _startsWith(name, 'docimage:')) {
+      const fileName = name.split(':')[1];
       return <span {...props} className={classNames}><img className="image" src={baseURL !== undefined ? baseURL + fileName : dynamicRequire(fileName)} /></span>;
     } else {
       return <span {...props} className={classNames}>{this.props.children}</span>;

--- a/webapp/src/js/stores/ConfigStore.js
+++ b/webapp/src/js/stores/ConfigStore.js
@@ -117,10 +117,9 @@ const ConfigStore = createStore({
       table.quickFindFields = table.quickFindFields ? _map(table.quickFindFields.split(','), (s) => s.trim()) : [table.primKey];
       table.previewProperties = table.previewProperties ? _map(table.previewProperties.split(','), (s) => s.trim()) : null;
       //TODO Remove the fa here for now - should be in settings
-      if (table.icon)
+      if (table.icon && table.icon.indexOf(':') === -1)
         table.icon = table.icon.substring(3);
-      else
-        table.icon = 'table';
+      table.icon = table.icon || 'table';
       table.propertyGroupsById = {};
       table.propertyGroups.forEach((group) => {
         table.propertyGroupsById[group.id] = group;


### PR DESCRIPTION
Adds `button` prop to `ItemLink` such that the link is rendered like a button, using the linkee tables icon.

Also adds `docimage:` icon path which reduces need for `baseURL` in icon tags.