### PR TITLE
Remove prop passing in docs

### DIFF
--- a/webapp/src/js/components/panoptes/DocPage.js
+++ b/webapp/src/js/components/panoptes/DocPage.js
@@ -10,6 +10,7 @@ import htmlparser from 'htmlparser2';
 import Loading from 'ui/Loading';
 import IconButton from '@material-ui/core/IconButton';
 import customHandlebars from 'util/customHandlebars';
+import _isFunction from 'lodash.isfunction';
 
 // Mixins
 import ConfigMixin from 'mixins/ConfigMixin';
@@ -145,14 +146,14 @@ let DocPage = createReactClass({
   },
 
   render() {
-    const {path, dynamicSize, ...otherProps} = this.props;
+    const {path, dynamicSize} = this.props;
     const {content, loadStatus} = this.state;
     const replaceSelf = this.props.replaceable ? this.props.replaceSelf : undefined;
     const actions = this.getFlux().actions;
     // NOTE: z-index of the Edit modal is currently set to 9997.
     const editButtonZIndex = 9996;
     return <div className={dynamicSize ? '' : 'load-container'}>
-      <HTMLWithComponents className="doc-page" replaceSelf={replaceSelf} {...otherProps}>{content}</HTMLWithComponents>
+      <HTMLWithComponents className="doc-page" replaceSelf={replaceSelf}>{content}</HTMLWithComponents>
       {this.config.user.isManager ?
         <div className="docpage-edit"  style={{zIndex: editButtonZIndex}}>
           <IconButton

--- a/webapp/src/js/components/panoptes/HTMLWithComponents.js
+++ b/webapp/src/js/components/panoptes/HTMLWithComponents.js
@@ -29,7 +29,7 @@ class HTMLWithComponents extends React.Component {
 
   static propTypes = {
     className: PropTypes.string,
-    children: PropTypes.string, // NOTE: children is not usually a STRING
+    children: PropTypes.string,
     replaceSelf: PropTypes.func
   };
 
@@ -94,13 +94,11 @@ class HTMLWithComponents extends React.Component {
             }
           });
 
-          const {replaceSelf, config, className, ...otherProps} = this.props;
+          const {replaceSelf} = this.props;
           if (type === DocLink) {
             elementProps.replaceParent = replaceSelf;
           }
-
-          const mergedProps = {...elementProps, ...otherProps};
-          return React.createElement(type, mergedProps, children);
+          return React.createElement(type, elementProps, children);
         }
       },
       {
@@ -118,22 +116,10 @@ class HTMLWithComponents extends React.Component {
   }
 
   render() {
-
     const {children, className, ...otherProps} = this.props;
     // NOTE: wrapping avoids "Error: html-to-react currently only supports HTML with one single root element. The HTML provided contains 0 root elements. You can fix that by simply wrapping your HTML in a <div> element."
     // The original children will be inside this temporary wrapper, but now React.
-    const wrappedChildrenAsReact = this.htmlToReact(`<div>${children}</div>`);
-
-    //// Pass all otherProps to all immediate React Component children.
-    // child is a string when it is just a text node.
-    // child has a function type (as opposed to string) when it is a React Component.
-    // Passing otherProps to a DOM element might generate warnings.
-    // TODO: iterator should have a unique "key" prop
-    const childrenAsReactWithProps = wrappedChildrenAsReact.props.children.map((child, index) =>
-      typeof child === 'string' ? child : (typeof child.type === 'function' ? React.cloneElement(child, otherProps) : child)
-    );
-
-    return <div className={className}>{childrenAsReactWithProps}</div>;
+    return this.htmlToReact(`<div class="${className}">${children}</div>`);
   }
 }
 


### PR DESCRIPTION
To properly pass down state we'll need to further customise the HTML parsing. In an attempt to avoid this and simplify things I have remove the prop passing from `HTMLWithComponents`. Views will need to be direct children of a `SessionComponent` to get `setProps`.