### PR TITLE
Static content cache header

### DIFF
--- a/server/wsgi_server.py
+++ b/server/wsgi_server.py
@@ -16,7 +16,7 @@ from werkzeug.wrappers import Response
 
 general_with_static = SharedDataMiddleware(wsgi_general.application, {
     '/': os.path.join(os.path.dirname(config.__file__), 'webapp/dist')
-}, cache_timeout=1)
+})
 api_application = DispatcherMiddleware(general_with_static, {
     '/panoptes/api':        wsgi_api.application,
 })

--- a/server/wsgi_server.py
+++ b/server/wsgi_server.py
@@ -16,7 +16,7 @@ from werkzeug.wrappers import Response
 
 general_with_static = SharedDataMiddleware(wsgi_general.application, {
     '/': os.path.join(os.path.dirname(config.__file__), 'webapp/dist')
-})
+}, cache_timeout=60*60)
 api_application = DispatcherMiddleware(general_with_static, {
     '/panoptes/api':        wsgi_api.application,
 })


### PR DESCRIPTION
Given the dev env serves JS from a different endpoint and the built JS comes with a content hash we can afford a constant static content timeout. Will review if it becomes a problem.