### PR TITLE
Add resetScroll mechanism for dynamic height components

### DIFF
--- a/webapp/src/js/components/DataItem.js
+++ b/webapp/src/js/components/DataItem.js
@@ -25,6 +25,7 @@ let DataItem = createReactClass({
 
   propTypes: {
     setProps: PropTypes.func,
+    resetScroll: PropTypes.func,
     table: PropTypes.string.isRequired,
     primKey: PropTypes.string.isRequired,
     activeTab: PropTypes.string,
@@ -43,6 +44,14 @@ let DataItem = createReactClass({
 
   title() {
     return `${this.config.tablesById[this.props.table].capNameSingle} "${this.props.primKey}"`;
+  },
+
+  componentWillUpdate(nextProps) {
+    if (this.props.resetScroll && (
+      this.props.table !== nextProps.table ||
+      this.props.primKey !== nextProps.primKey ||
+      this.props.children !== nextProps.children
+    )) this.props.resetScroll();
   },
 
   render() {

--- a/webapp/src/js/components/panoptes/DocPage.js
+++ b/webapp/src/js/components/panoptes/DocPage.js
@@ -39,6 +39,7 @@ let DocPage = createReactClass({
     path: PropTypes.string,
     replaceSelf: PropTypes.func,
     updateTitleIcon: PropTypes.func,
+    resetScroll: PropTypes.func,
     replaceable: PropTypes.bool,
     dynamicSize: PropTypes.bool,
     setProps: PropTypes.func,
@@ -54,6 +55,7 @@ let DocPage = createReactClass({
   componentWillMount() {
     this.titleFromHTML = 'Loading...';
     this.handlebars = customHandlebars(this.config);
+    if (this.props.resetScroll) this.props.resetScroll();
   },
 
   onConfigChange() {
@@ -109,6 +111,9 @@ let DocPage = createReactClass({
   },
 
   componentWillUpdate(nextProps, nextState) {
+    if (this.props.resetScroll & nextState.content !== this.state.content) {
+      this.props.resetScroll();
+    }
     let inTitle = false;
     let title = 'Untitled';
     const parser = new htmlparser.Parser({

--- a/webapp/src/js/components/panoptes/FeedIndex.js
+++ b/webapp/src/js/components/panoptes/FeedIndex.js
@@ -29,12 +29,17 @@ let FeedIndex = createReactClass({
     setProps: PropTypes.func,
     replaceSelf: PropTypes.func,
     replaceParent: PropTypes.func,
+    resetScroll: PropTypes.func
   },
 
   getDefaultProps() {
     return {
       selectedTags: '',
     };
+  },
+
+  componentWillMount() {
+    if (this.props.resetScroll) this.props.resetScroll();
   },
 
   render() {

--- a/webapp/src/js/components/panoptes/FeedItem.js
+++ b/webapp/src/js/components/panoptes/FeedItem.js
@@ -20,6 +20,18 @@ let FeedItem = createReactClass({
   propTypes: {
     feedId: PropTypes.string,
     itemId: PropTypes.string,
+    resetScroll: PropTypes.func
+  },
+
+  componentWillMount() {
+    if (this.props.resetScroll) this.props.resetScroll();
+  },
+
+  componentWillUpdate(nextProps) {
+    if (this.props.resetScroll && (
+      this.props.feedId !== nextProps.feedId ||
+      this.props.itemId !== nextProps.itemId
+    )) this.props.resetScroll();
   },
 
   render() {

--- a/webapp/src/js/components/panoptes/SessionComponent.js
+++ b/webapp/src/js/components/panoptes/SessionComponent.js
@@ -16,6 +16,7 @@ let SessionComponent = createReactClass({
   propTypes: {
     compId: PropTypes.string,
     updateTitleIcon: PropTypes.func,
+    resetScroll: PropTypes.func,
     replaceable: PropTypes.bool
   },
 
@@ -63,7 +64,7 @@ let SessionComponent = createReactClass({
   },
 
   render() {
-    const {compId, replaceable} = this.props;
+    const {compId, replaceable, resetScroll} = this.props;
     let component = this.getFlux().store('SessionStore').getState().getIn(['components', compId]);
     this.lastRendered = component;
     let actions = this.getFlux().actions.session;
@@ -71,7 +72,8 @@ let SessionComponent = createReactClass({
       {component ? React.cloneElement(deserialiseComponent(component, [compId], {
           setProps: actions.componentSetProps,
           replaceSelf: actions.componentReplace,
-          updateTitleIcon: this.updateTitleIcon
+          updateTitleIcon: this.updateTitleIcon,
+          resetScroll
         }), {ref: 'child', replaceable})
         : <span>Component does not exist</span>}
     </ErrorBoundary>;


### PR DESCRIPTION
In this PR, dynamic height components are given a function to call when they wish to reset the scroll position of the container. It may be better to have such components have their own internal scrolling element - but that would not only be a more involved change but it would also mean they could never be concatenated vertically on a page.

It is easy to imagine how this could be extended to scroll to specific elements for linking to anchors and also storing scroll state in the back button.