### PR TITLE
Point user to root URL after error

### DIFF
--- a/webapp/src/js/components/ErrorBoundary.js
+++ b/webapp/src/js/components/ErrorBoundary.js
@@ -22,11 +22,7 @@ class ErrorBoundary extends React.Component {
       return (
         <div>
           <h2>An error has occurred.</h2>
-          <details style={{whiteSpace: 'pre-wrap'}}>
-            {this.state.error && this.state.error.toString()}
-            <br />
-            {this.state.errorInfo.componentStack}
-          </details>
+          Click <a href={window.rootURL}>{window.rootURL}</a> to reset the app.
         </div>
       );
     }

--- a/webapp/src/js/index.js
+++ b/webapp/src/js/index.js
@@ -79,7 +79,7 @@ if (dataset === undefined || dataset === null || dataset === '') {
   let promises = [InitialConfig(dataset)];
 
   const remainingPath = datasetURLPathParts.slice(1).join('/');
-
+  window.rootURL = window.location.origin + process.env.DATASET_URL_PATH_PREFIX + dataset;
   // Match the UID and nothing but the UID.
   const HASH_REGEX = /^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$/;
   const matches = HASH_REGEX.exec(remainingPath);


### PR DESCRIPTION
The URL is passed via `window` as in an Error state config may not be available to recreate it.