### PR TITLE
Reprogram initial column-widths

### DIFF
--- a/server/responders/importer/ImportDataTable.py
+++ b/server/responders/importer/ImportDataTable.py
@@ -62,6 +62,9 @@ class ImportDataTable(BaseImport):
                 if 'maxVal' not in prop and prop['dataType'] in valueTypes:
                     result['maxVal'] = \
                     encode(self._dao._execSqlQuery('select max("{0}") from "{1}"'.format(prop_id, table_id))[0][0])
+                if 'pc90Len' not in prop and prop['dataType'] not in valueTypes:
+                    # Not using for valueTypes because 0.00000001 might be reformatted (e.g. for display) as 0.00
+                    result['pc90Len'] = encode(self._dao._execSqlQuery('select sys.quantile(length("{0}"),0.9) from "{1}" where "{0}" is not null'.format(prop_id, table_id))[0][0])
                 if 'minVal' not in prop and prop['dataType'] in valueTypes:
                     result['minVal'] = \
                     encode(self._dao._execSqlQuery('select min("{0}") from "{1}"'.format(prop_id, table_id))[0][0])

--- a/server/responders/importer/ImportSettings.py
+++ b/server/responders/importer/ImportSettings.py
@@ -154,14 +154,19 @@ class ImportSettings:
                             ('minVal', {
                                    'type': 'Value',
                                    'required': False,
-                                   'description': 'Set automatically from data unless overridden. For *Value* types, upper extent of scale',
+                                   'description': 'Set automatically from data unless overridden. For *Value* types, lower extent of scale',
                                    'siblingOptional': { 'name': 'dataType', 'value': valueTypes}
                                    }),
                             ('maxVal', {
                                    'type': 'Value',
                                    'required': False,
-                                   'description': 'Set automatically from data unless overridden. For *Value* types, lower extent of scale',
+                                   'description': 'Set automatically from data unless overridden. For *Value* types, upper extent of scale',
                                    'siblingOptional': { 'name': 'dataType', 'value': valueTypes}
+                                   }),
+                            ('pc90Len', {
+                                   'type': 'Value',
+                                   'required': False,
+                                   'description': 'Set automatically from data unless overridden. For non-*Value* types, the 90th percentile character-length.',
                                    }),
                             ('decimDigits', {
                                    'type': 'Value',

--- a/server/responders/importer/SettingsDataTable.py
+++ b/server/responders/importer/SettingsDataTable.py
@@ -457,7 +457,7 @@ containing the relative size of that specific pie'''
                                                            }),
                                                 ('pc90Len', {
                                                            'type': 'Value',
-                                                           'required': True,
+                                                           'required': False,
                                                            'description': 'Value used for 90th percentile character-length'
                                                            }),
                                                 ('blockSizeMin', {

--- a/server/responders/importer/SettingsDataTable.py
+++ b/server/responders/importer/SettingsDataTable.py
@@ -455,6 +455,11 @@ containing the relative size of that specific pie'''
                                                            'required': True,
                                                            'description': 'Value used for upper extent of scales'
                                                            }),
+                                                ('pc90Len', {
+                                                           'type': 'Value',
+                                                           'required': True,
+                                                           'description': 'Value used for 90th percentile character-length'
+                                                           }),
                                                 ('blockSizeMin', {
                                                              'type': 'Value',
                                                              'required': True,

--- a/webapp/src/js/components/panoptes/DataTableView.js
+++ b/webapp/src/js/components/panoptes/DataTableView.js
@@ -276,6 +276,7 @@ let DataTableView = createReactClass({
 
         if (!isNumerical && pc90Len === undefined) {
           console.error('initialColumnWidthMode is maxVal-or-pc90Len and column !isNumerical but pc90Len is undefined for column', column);
+          console.info('pc90Len is set by import');
           break;
         }
 

--- a/webapp/src/js/components/panoptes/DataTableView.js
+++ b/webapp/src/js/components/panoptes/DataTableView.js
@@ -245,7 +245,7 @@ let DataTableView = createReactClass({
     for (let columnIndex = 0, columnCount = columns.length; columnIndex < columnCount; columnIndex++) {
       const column = columns[columnIndex];
       const columnData = this.propertiesByColumn(column);
-      const {isNumerical, maxVal, pc90Len, externalUrl} = columnData;
+      const {isNumerical, maxVal, pc90Len, externalUrl, isBoolean} = columnData;
 
       let elementToMeasure = undefined;
       let elementAdditionalWidthPx = undefined;
@@ -264,7 +264,6 @@ let DataTableView = createReactClass({
           break;
         }
 
-
         if (document.getElementsByClassName('table-row-cell') === undefined || document.getElementsByClassName('table-row-cell').length === 0) {
           // table-row-cell is not available (yet) to measure.
           calculatingColumnWidths = {}; // Invalidate any knowns gathered so far.
@@ -276,7 +275,8 @@ let DataTableView = createReactClass({
 
         // TODO: Sync with CSS (.table-row-cell)
         // Firefox needs an extra 3px compared to Chrome.
-        elementAdditionalWidthPx = 20 + 3 + (externalUrl !== undefined ? 14 : 0);
+        // NOTE: <Column> has minWidth={50}, which applies to manual resizing.
+        elementAdditionalWidthPx = 20 + 3 + (externalUrl !== undefined ? 14 : 0) + (isBoolean ? 27 : 0);
 
         if (isNumerical && maxVal !== undefined) {
 

--- a/webapp/src/js/components/panoptes/PropertyCell.js
+++ b/webapp/src/js/components/panoptes/PropertyCell.js
@@ -57,7 +57,7 @@ let PropertyCell = createReactClass({
       content = refs.map((ref, index) => (
         <span key={index}>
           {index === 0 ? externalLinkIcon : null}
-          <a target="_blank" href={prop.externalUrl.replace('{value}', ref)}>
+          <a target="_blank" rel="noopener noreferrer" href={prop.externalUrl.replace('{value}', ref)}>
             {ref}
           </a>
           {index < refs.length - 1 ? ', ' : null}

--- a/webapp/src/styles/ui-components.scss
+++ b/webapp/src/styles/ui-components.scss
@@ -315,6 +315,7 @@
   justify-content: space-between;
   align-items: flex-start;
   align-content: flex-start;
+  margin-top: 10px; // In core colours, prevents collision with element above.
   .icon-holder {
     order: 0;
     flex-basis: auto;


### PR DESCRIPTION
For https://github.com/wtchg-kwiatkowski/observatory-web/issues/215

This is horrible, but an improvement!

One known issue causes inconsistent widths of Fst columns in obs-web.

`MuiDataTableView` doesn't need any of this, btw.
