### PR TITLE
 Fix bug: set currentOperator to first validOperator when currentOperator is not valid

### DIFF
--- a/webapp/src/js/components/panoptes/QueryEditor.js
+++ b/webapp/src/js/components/panoptes/QueryEditor.js
@@ -269,9 +269,12 @@ let Criterion = createReactClass({
     // If the currentOperator is one of the validOperators for the new property,
     // then continue to use it.
     let currentOperator = validOperators.filter((op) => op.ID === component.type)[0];
+
     // Otherwise use the first of the validOperators for the new property.
-    if (!currentOperator)
+    if (!currentOperator) {
+      currentOperator = validOperators[0];
       component.type = validOperators[0].ID;
+    }
 
     // If there is still no operator, then throw a wobbly.
     if (!currentOperator)

--- a/webapp/yarn.lock
+++ b/webapp/yarn.lock
@@ -6238,7 +6238,7 @@ kdbush@^1.0.1:
   version "1.0.1"
   resolved "http://registry.npmjs.org/kdbush/-/kdbush-1.0.1.tgz#3cbd03e9dead9c0f6f66ccdb96450e5cecc640e0"
 
-keycode@^2.1.7, keycode@^2.1.9:
+keycode@^2.1.9:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/keycode/-/keycode-2.2.0.tgz#3d0af56dc7b8b8e5cba8d0a97f107204eec22b04"
 
@@ -8525,7 +8525,7 @@ react-dom@^16.0.0:
     classnames "^2.2.5"
     prop-types "^15.6.0"
 
-react-event-listener@^0.6.0, react-event-listener@^0.6.2:
+react-event-listener@^0.6.2:
   version "0.6.4"
   resolved "https://registry.yarnpkg.com/react-event-listener/-/react-event-listener-0.6.4.tgz#d0ea5ed897da1a796616c44b5a8758898140f203"
   dependencies:
@@ -8636,35 +8636,6 @@ react-resizable@^1.6.0:
 react-sidebar@^2.3.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/react-sidebar/-/react-sidebar-2.3.2.tgz#ec140bea8a6f5fa3d8ea7a56479665b44cf4f9cf"
-
-react-swipeable-views-core@^0.12.17:
-  version "0.12.17"
-  resolved "https://registry.yarnpkg.com/react-swipeable-views-core/-/react-swipeable-views-core-0.12.17.tgz#0998f55fd2f8595bcd01bead1c19516dc561c1cf"
-  dependencies:
-    "@babel/runtime" "7.0.0"
-    warning "^4.0.1"
-
-react-swipeable-views-utils@^0.12.18:
-  version "0.12.18"
-  resolved "https://registry.yarnpkg.com/react-swipeable-views-utils/-/react-swipeable-views-utils-0.12.18.tgz#6edfcc9d722901f0edaf79c78bc6c4a7cc25da81"
-  dependencies:
-    "@babel/runtime" "7.0.0"
-    fbjs "^0.8.4"
-    keycode "^2.1.7"
-    prop-types "^15.6.0"
-    react-event-listener "^0.6.0"
-    react-swipeable-views-core "^0.12.17"
-
-react-swipeable-views@^0.12.5:
-  version "0.12.18"
-  resolved "https://registry.yarnpkg.com/react-swipeable-views/-/react-swipeable-views-0.12.18.tgz#3b5d75bbfb826553fe0e42bc04b9c1c4b45acd77"
-  dependencies:
-    "@babel/runtime" "7.0.0"
-    dom-helpers "^3.2.1"
-    prop-types "^15.5.4"
-    react-swipeable-views-core "^0.12.17"
-    react-swipeable-views-utils "^0.12.18"
-    warning "^4.0.1"
 
 react-transition-group@^1.2.0:
   version "1.2.1"


### PR DESCRIPTION
(Note: this does *not* fyx obs-web 309, which I'm re-shelving, but feel free to delete this branch after merge.)